### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/misc/parse_cover.py
+++ b/misc/parse_cover.py
@@ -19,7 +19,7 @@ for line in sys.stdin:
     continue
 
   m = coverage_pattern.search(line)
-  if m != None:
+  if m is not None:
     coverage_count += 1
     coverage_sum += float(m.group(1) + "." + m.group(2))
     continue

--- a/py/vtctl/grpc_vtctl_client.py
+++ b/py/vtctl/grpc_vtctl_client.py
@@ -39,7 +39,7 @@ class GRPCVtctlClient(vtctl_client.VctlClient):
         self.stub = None
 
     def is_closed(self):
-        return self.stub == None
+        return self.stub is None
 
     def execute_vtctl_command(self, args, action_timeout=30.0,
                               lock_timeout=5.0, info_to_debug=False):

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -541,7 +541,7 @@ class Tablet(object):
   def wait_for_vtocc_state(self, expected, timeout=60.0, port=None):
     while True:
       v = utils.get_vars(port or self.port)
-      if v == None:
+      if v is None:
         logging.debug(
             '  vttablet %s not answering at /debug/vars, waiting...',
             self.tablet_alias)
@@ -605,7 +605,7 @@ class Tablet(object):
   def wait_for_binlog_server_state(self, expected, timeout=30.0):
     while True:
       v = utils.get_vars(self.port)
-      if v == None:
+      if v is None:
         logging.debug('  vttablet not answering at /debug/vars, waiting...')
       else:
         if 'UpdateStreamState' not in v:
@@ -626,7 +626,7 @@ class Tablet(object):
   def wait_for_binlog_player_count(self, expected, timeout=30.0):
     while True:
       v = utils.get_vars(self.port)
-      if v == None:
+      if v is None:
         logging.debug('  vttablet not answering at /debug/vars, waiting...')
       else:
         if 'BinlogPlayerMapSize' not in v:

--- a/test/utils.py
+++ b/test/utils.py
@@ -87,7 +87,7 @@ def main(mod=None, test_options=None):
     test_options - a function which adds OptionParser options that are specific
       to a test file.
   """
-  if mod == None:
+  if mod is None:
     mod = sys.modules['__main__']
 
   global options


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:vitess?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:vitess?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
