### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/py/vtdb/dbapi.py
+++ b/py/vtdb/dbapi.py
@@ -19,7 +19,7 @@ class BindVarsProxy(object):
     return ':%s' % name
 
   def export_bind_vars(self):
-    return dict([(k, self.bind_vars[k]) for k in self.accessed_keys])
+    return {k: self.bind_vars[k] for k in self.accessed_keys}
 
 
 # convert bind style from %(name)s to :name and export only the

--- a/py/zk/zkjson.py
+++ b/py/zk/zkjson.py
@@ -5,9 +5,9 @@ import json
 
 def _default(o):
   if hasattr(o, '_serializable_attributes'):
-    return dict([(k, v)
+    return {k: v
                  for k, v in o.__dict__.iteritems()
-                 if k in o._serializable_attributes])
+                 if k in o._serializable_attributes}
   return o.__dict__
 
 _default_kargs = {'default': _default,

--- a/test/keyrange_test.py
+++ b/test/keyrange_test.py
@@ -34,7 +34,7 @@ int_shard_kid_map = {'-10':[1, 100, 1000, 100000, 527875958493693904, 6267509316
 
 # str_shard_kid_map is derived from int_shard_kid_map
 # by generating bin-packed strings from the int keyspace_id values.
-str_shard_kid_map = dict([(shard_name, [pkid_pack(kid) for kid in kid_list]) for shard_name, kid_list in int_shard_kid_map.iteritems()])
+str_shard_kid_map = {shard_name: [pkid_pack(kid) for kid in kid_list] for shard_name, kid_list in int_shard_kid_map.iteritems()}
 
 class TestKeyRange(unittest.TestCase):
 

--- a/third_party/py/bson-0.3.2/bson/codec.py
+++ b/third_party/py/bson-0.3.2/bson/codec.py
@@ -336,5 +336,5 @@ ELEMENT_TYPES = {
 	}
 
 # optimize dispatch once all methods are known
-ELEMENT_DISPATCH = dict([(chr(i), globals()["decode_" + name + "_element"])
-		    for i, name in ELEMENT_TYPES.iteritems()])
+ELEMENT_DISPATCH = {chr(i): globals()["decode_" + name + "_element"]
+		    for i, name in ELEMENT_TYPES.iteritems()}


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:vitess?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:vitess?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
