### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/demo/cgi-bin/data.py
+++ b/examples/demo/cgi-bin/data.py
@@ -41,7 +41,7 @@ def exec_query(cursor, title, query, response):
         }
 
 def capture_log(prefix, port, queries):
-  p = subprocess.Popen(["curl", "-s", "-N", "http://localhost:%d/debug/querylog" % port], stdout=subprocess.PIPE)
+  p = subprocess.Popen(["curl", "-s", "-N", "http://localhost:{0:d}/debug/querylog".format(port)], stdout=subprocess.PIPE)
   def collect():
     for line in iter(p.stdout.readline, ''):
       query = line.split("\t")[10].strip('"')

--- a/examples/kubernetes/guestbook/main.py
+++ b/examples/kubernetes/guestbook/main.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
   timeout = 10 # connect timeout in seconds
 
   # Get vtgate service address from Kubernetes environment.
-  addr = '%s:%s' % (os.environ['VTGATE_SERVICE_HOST'], os.environ['VTGATE_SERVICE_PORT'])
+  addr = '{0!s}:{1!s}'.format(os.environ['VTGATE_SERVICE_HOST'], os.environ['VTGATE_SERVICE_PORT'])
 
   # Connect to vtgate.
   conn = vtgatev2.connect({'vt': [addr]}, timeout)

--- a/go/cmd/zkns2pdns/test.py
+++ b/go/cmd/zkns2pdns/test.py
@@ -6,7 +6,7 @@ def main(args):
   print 'HELO\t2'
   if args:
     for arg in args:
-      print "Q\t%s\tIN\tANY\t-1\t1.1.1.1\t1.1.1.2" % arg
+      print "Q\t{0!s}\tIN\tANY\t-1\t1.1.1.1\t1.1.1.2".format(arg)
   else:
     print "Q\ttest.zkns.zk\tIN\tANY\t-1\t1.1.1.1\t1.1.1.2"
 

--- a/misc/parse_cover.py
+++ b/misc/parse_cover.py
@@ -27,5 +27,5 @@ for line in sys.stdin:
 directories_covered = coverage_count * 100 / (no_test_file_count + coverage_count)
 average_coverage = coverage_sum / coverage_count
 
-print "Directory test coverage: %u%%" % directories_covered
-print "Average test coverage: %u%%" % int(average_coverage)
+print "Directory test coverage: {0:d}%".format(directories_covered)
+print "Average test coverage: {0:d}%".format(int(average_coverage))

--- a/py/cbson/test_cbson.py
+++ b/py/cbson/test_cbson.py
@@ -202,8 +202,8 @@ if __name__ == "__main__":
   print "Running selftest:"
   status = doctest.testmod(sys.modules[__name__])
   if status[0]:
-    print "*** %s tests of %d failed." % status
+    print "*** {0!s} tests of {1:d} failed.".format(*status)
     sys.exit(1)
   else:
-    print "--- %s tests passed." % status[1]
+    print "--- {0!s} tests passed.".format(status[1])
     sys.exit(0)

--- a/py/cbson/test_cbson_bad_data.py
+++ b/py/cbson/test_cbson_bad_data.py
@@ -39,17 +39,17 @@ class CbsonTest(unittest.TestCase):
 
   def test_random_segfaults(self):
     a = cbson.dumps({"A": [1, 2, 3, 4, 5, "6", u"7", {"C": u"DS"}]})
-    sys.stdout.write("\nQ: %s\n" % (binascii.hexlify(a),))
+    sys.stdout.write("\nQ: {0!s}\n".format(binascii.hexlify(a)))
     for i in range(1000):
       l = [c for c in a]
       l[random.randint(4, len(a)-1)] = chr(random.randint(0, 255))
       try:
         s = "".join(l)
-        sys.stdout.write("s: %s\n" % (binascii.hexlify(s),))
+        sys.stdout.write("s: {0!s}\n".format(binascii.hexlify(s)))
         sys.stdout.flush()
         cbson.loads(s)
       except Exception as e:
-        sys.stdout.write("  ERROR: %r\n" % (e,))
+        sys.stdout.write("  ERROR: {0!r}\n".format(e))
         sys.stdout.flush()
 
 if __name__ == "__main__":

--- a/py/net/bsonrpc.py
+++ b/py/net/bsonrpc.py
@@ -42,9 +42,9 @@ class BsonRpcClient(gorpc.GoRpcClient):
     else:
       protocol = 'http'
     if self.user:
-      uri = '%s://%s/_bson_rpc_/auth' % (protocol, self.addr)
+      uri = '{0!s}://{1!s}/_bson_rpc_/auth'.format(protocol, self.addr)
     else:
-      uri = '%s://%s/_bson_rpc_' % (protocol, self.addr)
+      uri = '{0!s}://{1!s}/_bson_rpc_'.format(protocol, self.addr)
     gorpc.GoRpcClient.__init__(self, uri, timeout, keyfile=keyfile, certfile=certfile, socket_file=socket_file)
 
   def dial(self):

--- a/py/net/gorpc.py
+++ b/py/net/gorpc.py
@@ -95,7 +95,7 @@ class _GoRpcConn(object):
       self.conn = socket.create_connection((conip, int(conport)), self.socket_timeout)
       if parts.scheme == 'https':
         self.conn = ssl.wrap_socket(self.conn, keyfile=keyfile, certfile=certfile)
-    self.conn.sendall('CONNECT %s HTTP/1.0\n\n' % parts.path)
+    self.conn.sendall('CONNECT {0!s} HTTP/1.0\n\n'.format(parts.path))
     data = ''
     while True:
       try:
@@ -105,7 +105,7 @@ class _GoRpcConn(object):
           continue
         raise
       if not d:
-        raise GoRpcError('Unexpected EOF in handshake to %s:%s %s' % (str(conip), str(conport), parts.path))
+        raise GoRpcError('Unexpected EOF in handshake to {0!s}:{1!s} {2!s}'.format(str(conip), str(conport), parts.path))
       data += d
       if '\n\n' in data:
         return
@@ -229,8 +229,8 @@ class GoRpcClient(object):
       raise ProgrammingError('no request pending')
     if not self.conn:
       raise GoRpcError(
-          '_read_response - closed client: %s' %
-          (time.time() - self.start_time))
+          '_read_response - closed client: {0!s}'.format(
+          (time.time() - self.start_time)))
 
     # get some data if we don't have any so we have somewhere to start
     if self.data is None:

--- a/py/vtctl/gorpc_vtctl_client.py
+++ b/py/vtctl/gorpc_vtctl_client.py
@@ -22,7 +22,7 @@ class GoRpcVtctlClient(vtctl_client.VctlClient):
     self.connected = False
 
   def __str__(self):
-    return '<VtctlClient %s>' % self.addr
+    return '<VtctlClient {0!s}>'.format(self.addr)
 
   def dial(self):
     if self.connected:

--- a/py/vtctl/grpc_vtctl_client.py
+++ b/py/vtctl/grpc_vtctl_client.py
@@ -24,7 +24,7 @@ class GRPCVtctlClient(vtctl_client.VctlClient):
         self.stub = None
 
     def __str__(self):
-        return '<VtctlClient %s>' % self.addr
+        return '<VtctlClient {0!s}>'.format(self.addr)
 
     def dial(self):
         if self.stub:

--- a/py/vtdb/db_object.py
+++ b/py/vtdb/db_object.py
@@ -162,7 +162,7 @@ def db_wrapper(method, **decorator_kwargs):
     write_method = kwargs.get("write_method", False)
     if not issubclass(table_class, DBObjectBase):
       raise dbexceptions.ProgrammingError(
-          "table class '%s' is not inherited from DBObjectBase" % table_class)
+          "table class '{0!s}' is not inherited from DBObjectBase".format(table_class))
 
     # Create the cursor using cursor_method
     cursor_method = pargs[1]
@@ -215,7 +215,7 @@ def execute_batch_read(cursor, query_list, bind_vars_list):
   batch_cursor = create_batch_cursor_from_cursor(cursor)
   for q, bv in zip(query_list, bind_vars_list):
     if is_dml(q):
-      raise dbexceptions.ProgrammingError("Dml %s for read batch cursor." % q)
+      raise dbexceptions.ProgrammingError("Dml {0!s} for read batch cursor.".format(q))
     batch_cursor.execute(q, bv)
 
   batch_cursor.flush()
@@ -256,7 +256,7 @@ def execute_batch_write(cursor, query_list, bind_vars_list):
         "writable batch execute can also execute on one keyspace_id.")
   for q, bv in zip(query_list, bind_vars_list):
     if not is_dml(q):
-      raise dbexceptions.ProgrammingError("query %s is not a dml" % q)
+      raise dbexceptions.ProgrammingError("query {0!s} is not a dml".format(q))
     batch_cursor.execute(q, bv)
 
   batch_cursor.flush()

--- a/py/vtdb/db_object_range_sharded.py
+++ b/py/vtdb/db_object_range_sharded.py
@@ -106,7 +106,7 @@ class DBObjectRangeSharded(db_object.DBObjectBase):
 
     # entity_id_map is not None
     if len(entity_id_map) != 1:
-      dbexceptions.ProgrammingError("Invalid entity_id_map '%s'" % entity_id_map)
+      dbexceptions.ProgrammingError("Invalid entity_id_map '{0!s}'".format(entity_id_map))
 
     entity_id_col = entity_id_map.keys()[0]
     entity_id = entity_id_map[entity_id_col]
@@ -118,7 +118,7 @@ class DBObjectRangeSharded(db_object.DBObjectBase):
       # Routing using sharding key.
       routing.sharding_key = entity_id
       if not class_.is_sharding_key_valid(routing.sharding_key):
-        raise dbexceptions.InternalError("Invalid sharding_key %s" % routing.sharding_key)
+        raise dbexceptions.InternalError("Invalid sharding_key {0!s}".format(routing.sharding_key))
     else:
       # Routing using lookup based entity.
       routing.entity_column_name = entity_id_col
@@ -431,7 +431,7 @@ class DBObjectEntityRangeSharded(DBObjectRangeSharded):
     if (not class_.entity_id_lookup_map
         or not isinstance(class_.entity_id_lookup_map, dict)):
       raise dbexceptions.ProgrammingError(
-          "Invalid entity_id_lookup_map %s" % class_.entity_id_lookup_map)
+          "Invalid entity_id_lookup_map {0!s}".format(class_.entity_id_lookup_map))
     entity_col = class_.entity_id_lookup_map.keys()[0]
 
     # Create the lookup entry first

--- a/py/vtdb/dbapi.py
+++ b/py/vtdb/dbapi.py
@@ -14,9 +14,9 @@ class BindVarsProxy(object):
     self.bind_vars[name]
     self.accessed_keys.add(name)
     if isinstance(var, (list, set, tuple)):
-      return '::%s' % name
+      return '::{0!s}'.format(name)
 
-    return ':%s' % name
+    return ':{0!s}'.format(name)
 
   def export_bind_vars(self):
     return dict([(k, self.bind_vars[k]) for k in self.accessed_keys])

--- a/py/vtdb/keyrange.py
+++ b/py/vtdb/keyrange.py
@@ -34,19 +34,19 @@ class KeyRange(codec.BSONCoding):
       else:
         kr = kr.split('-')
     if not isinstance(kr, tuple) and not isinstance(kr, list) or len(kr) != 2:
-      raise dbexceptions.ProgrammingError("keyrange must be a list or tuple or a '-' separated str %s" % kr)
+      raise dbexceptions.ProgrammingError("keyrange must be a list or tuple or a '-' separated str {0!s}".format(kr))
     self.Start = kr[0].strip().decode('hex')
     self.End = kr[1].strip().decode('hex')
 
   def __str__(self):
     if self.Start == keyrange_constants.MIN_KEY and self.End == keyrange_constants.MAX_KEY:
       return keyrange_constants.NON_PARTIAL_KEYRANGE
-    return '%s-%s' % (self.Start.encode('hex'), self.End.encode('hex'))
+    return '{0!s}-{1!s}'.format(self.Start.encode('hex'), self.End.encode('hex'))
 
   def __repr__(self):
     if self.Start == keyrange_constants.MIN_KEY and self.End == keyrange_constants.MAX_KEY:
-      return 'KeyRange(%r)' % keyrange_constants.NON_PARTIAL_KEYRANGE
-    return 'KeyRange(%r-%r)' % (self.Start, self.End)
+      return 'KeyRange({0!r})'.format(keyrange_constants.NON_PARTIAL_KEYRANGE)
+    return 'KeyRange({0!r}-{1!r})'.format(self.Start, self.End)
 
   def bson_encode(self):
     """Bson encode KeyRange.

--- a/py/vtdb/keyspace.py
+++ b/py/vtdb/keyspace.py
@@ -60,7 +60,7 @@ class Keyspace(object):
                             shard['KeyRange']['Start'],
                             shard['KeyRange']['End']):
         return shard['Name']
-    raise ValueError('cannot find shard for keyspace_id %s in %s' % (keyspace_id, shards))
+    raise ValueError('cannot find shard for keyspace_id {0!s} in {1!s}'.format(keyspace_id, shards))
 
 
 def _shard_contain_kid(pkid, start, end):

--- a/py/vtdb/tablet.py
+++ b/py/vtdb/tablet.py
@@ -81,7 +81,7 @@ class TabletConnection(object):
     self.logger_object = vtdb_logger.get_logger()
 
   def __str__(self):
-    return '<TabletConnection %s %s %s/%s>' % (self.addr, self.tablet_type, self.keyspace, self.shard)
+    return '<TabletConnection {0!s} {1!s} {2!s}/{3!s}>'.format(self.addr, self.tablet_type, self.keyspace, self.shard)
 
   def dial(self):
     try:

--- a/py/vtdb/topo_utils.py
+++ b/py/vtdb/topo_utils.py
@@ -38,7 +38,7 @@ def get_db_params_for_tablet_conn(topo_client, keyspace_name, shard, db_type, ti
     service = encrypted_service
   else:
     service = 'vt'
-  db_key = "%s.%s.%s:%s" % (keyspace_name, shard, db_type, service)
+  db_key = "{0!s}.{1!s}.{2!s}:{3!s}".format(keyspace_name, shard, db_type, service)
   # This will read the cached keyspace.
   keyspace_object = topology.get_keyspace(keyspace_name)
 
@@ -64,7 +64,7 @@ def get_db_params_for_tablet_conn(topo_client, keyspace_name, shard, db_type, ti
   encrypted_host_port_list = []
   if 'Entries' not in end_points_data:
     vtdb_logger.get_logger().topo_exception('topo server returned: ' + str(end_points_data), db_key, e)
-    raise Exception('zkocc returned: %s' % str(end_points_data))
+    raise Exception('zkocc returned: {0!s}'.format(str(end_points_data)))
   for entry in end_points_data['Entries']:
     if service in entry['NamedPortMap']:
       host_port = (entry['Host'], entry['NamedPortMap'][service],
@@ -83,6 +83,6 @@ def get_db_params_for_tablet_conn(topo_client, keyspace_name, shard, db_type, ti
 
 
   for host, port, encrypted in end_points_list:
-    vt_params = VTConnParams(keyspace_name, shard, db_type, "%s:%s" % (host, port), timeout, encrypted, user, password).__dict__
+    vt_params = VTConnParams(keyspace_name, shard, db_type, "{0!s}:{1!s}".format(host, port), timeout, encrypted, user, password).__dict__
     db_params_list.append(vt_params)
   return db_params_list

--- a/py/vtdb/topology.py
+++ b/py/vtdb/topology.py
@@ -150,7 +150,7 @@ def get_host_port_by_name(topo_client, db_key, encrypted=False):
     return []
   if 'Entries' not in data:
     vtdb_logger.get_logger().topo_exception('topo server returned: ' + str(data), db_key, e)
-    raise Exception('zkocc returned: %s' % str(data))
+    raise Exception('zkocc returned: {0!s}'.format(str(data)))
   for entry in data['Entries']:
     if service in entry['NamedPortMap']:
       host_port = (entry['Host'], entry['NamedPortMap'][service],

--- a/py/vtdb/vtclient.py
+++ b/py/vtdb/vtclient.py
@@ -94,7 +94,7 @@ class VtOCCConnection(object):
       raise
 
   def _connect(self):
-    db_key = "%s.%s.%s" % (self.keyspace, self.shard, self.db_type)
+    db_key = "{0!s}.{1!s}.{2!s}".format(self.keyspace, self.shard, self.db_type)
     db_params_list = get_vt_connection_params_list(self.topo_client,
                                                    self.keyspace,
                                                    self.shard,
@@ -106,7 +106,7 @@ class VtOCCConnection(object):
     if not db_params_list:
       # no valid end-points were found, re-read the keyspace
       self.resolve_topology()
-      raise dbexceptions.OperationalError("empty db params list - no db instance available for key %s" % db_key)
+      raise dbexceptions.OperationalError("empty db params list - no db instance available for key {0!s}".format(db_key))
     db_exception = None
     host_addr = None
     # no retries here, since there is a higher level retry with reconnect.

--- a/py/vtdb/vtgatev2.py
+++ b/py/vtdb/vtgatev2.py
@@ -120,7 +120,7 @@ class VTGateConnection(object):
     self.logger_object = vtdb_logger.get_logger()
 
   def __str__(self):
-    return '<VTGateConnection %s >' % self.addr
+    return '<VTGateConnection {0!s} >'.format(self.addr)
 
   def dial(self):
     try:
@@ -421,14 +421,14 @@ def get_params_for_vtgate_conn(vtgate_addrs, timeout, encrypted=False, user=None
     if encrypted:
       service = 'vts'
     if service not in vtgate_addrs:
-      raise Exception("required vtgate service addrs %s not exist" % service)
+      raise Exception("required vtgate service addrs {0!s} not exist".format(service))
     addrs = vtgate_addrs[service]
     random.shuffle(addrs)
   elif isinstance(vtgate_addrs, list):
     random.shuffle(vtgate_addrs)
     addrs = vtgate_addrs
   else:
-    raise dbexceptions.Error("Wrong type for vtgate addrs %s" % vtgate_addrs)
+    raise dbexceptions.Error("Wrong type for vtgate addrs {0!s}".format(vtgate_addrs))
 
   for addr in addrs:
     vt_params = dict()
@@ -447,7 +447,7 @@ def connect(vtgate_addrs, timeout, encrypted=False, user=None, password=None):
                                               password=password)
 
   if not db_params_list:
-   raise dbexceptions.OperationalError("empty db params list - no db instance available for vtgate_addrs %s" % vtgate_addrs)
+   raise dbexceptions.OperationalError("empty db params list - no db instance available for vtgate_addrs {0!s}".format(vtgate_addrs))
 
   db_exception = None
   host_addr = None

--- a/py/vtdb/vtgatev3.py
+++ b/py/vtdb/vtgatev3.py
@@ -102,7 +102,7 @@ class VTGateConnection(object):
     self.logger_object = vtdb_logger.get_logger()
 
   def __str__(self):
-    return '<VTGateConnection %s >' % self.addr
+    return '<VTGateConnection {0!s} >'.format(self.addr)
 
   def dial(self):
     try:

--- a/py/vtdb/vtrouting.py
+++ b/py/vtdb/vtrouting.py
@@ -61,7 +61,7 @@ class TaskKeyrangeMap(object):
     kr_chunks.append('')
     for i in xrange(self.num_tasks):
       kr += span
-      kr_chunks.append('%.2x' % kr)
+      kr_chunks.append('{0:.2x}'.format(kr))
     kr_chunks[-1] = ''
     for i in xrange(len(kr_chunks) - 1):
       start = kr_chunks[i]
@@ -126,7 +126,7 @@ def create_parallel_task_keyrange_map(num_tasks, shard_count):
   """
   if num_tasks % shard_count != 0:
     raise dbexceptions.ProgrammingError(
-        'tasks %d should be multiple of shard_count %d' % (num_tasks,
+        'tasks {0:d} should be multiple of shard_count {1:d}'.format(num_tasks,
                                                            shard_count))
   return TaskKeyrangeMap(num_tasks)
 
@@ -193,7 +193,7 @@ def _create_where_clause_for_keyrange(
   if (not isinstance(key_range, tuple) and not isinstance(key_range, list) or
       len(key_range) != 2):
     raise dbexceptions.ProgrammingError(
-        'key_range must be list or tuple or \'-\' separated str %s' % key_range)
+        'key_range must be list or tuple or \'-\' separated str {0!s}'.format(key_range))
 
   if keyspace_col_type == keyrange_constants.KIT_UINT64:
     return _create_where_clause_for_int_keyspace(key_range, keyspace_col_name)
@@ -201,7 +201,7 @@ def _create_where_clause_for_keyrange(
     return _create_where_clause_for_str_keyspace(key_range, keyspace_col_name)
   else:
     raise dbexceptions.ProgrammingError(
-        'Illegal type for keyspace_col_type %d' % keyspace_col_type)
+        'Illegal type for keyspace_col_type {0:d}'.format(keyspace_col_type))
 
 
 def _create_where_clause_for_str_keyspace(key_range, keyspace_col_name):
@@ -224,15 +224,15 @@ def _create_where_clause_for_str_keyspace(key_range, keyspace_col_name):
   bind_vars = {}
   i = 0
   if kr_min != keyrange_constants.MIN_KEY:
-    bind_name = '%s%d' % (keyspace_col_name, i)
-    where_clause = 'hex(%s) >= ' % keyspace_col_name + '%(' + bind_name + ')s'
+    bind_name = '{0!s}{1:d}'.format(keyspace_col_name, i)
+    where_clause = 'hex({0!s}) >= '.format(keyspace_col_name) + '%(' + bind_name + ')s'
     i += 1
     bind_vars[bind_name] = kr_min
   if kr_max != keyrange_constants.MAX_KEY:
     if where_clause != '':
       where_clause += ' AND '
-    bind_name = '%s%d' % (keyspace_col_name, i)
-    where_clause += 'hex(%s) < ' % keyspace_col_name + '%(' + bind_name + ')s'
+    bind_name = '{0!s}{1:d}'.format(keyspace_col_name, i)
+    where_clause += 'hex({0!s}) < '.format(keyspace_col_name) + '%(' + bind_name + ')s'
     bind_vars[bind_name] = kr_max
   return where_clause, bind_vars
 
@@ -257,14 +257,14 @@ def _create_where_clause_for_int_keyspace(key_range, keyspace_col_name):
   bind_vars = {}
   i = 0
   if kr_min is not None:
-    bind_name = '%s%d' % (keyspace_col_name, i)
-    where_clause = '%s >= ' % keyspace_col_name + '%(' + bind_name + ')s'
+    bind_name = '{0!s}{1:d}'.format(keyspace_col_name, i)
+    where_clause = '{0!s} >= '.format(keyspace_col_name) + '%(' + bind_name + ')s'
     i += 1
     bind_vars[bind_name] = kr_min
   if kr_max is not None:
     if where_clause != '':
       where_clause += ' AND '
-    bind_name = '%s%d' % (keyspace_col_name, i)
-    where_clause += '%s < ' % keyspace_col_name + '%(' + bind_name + ')s'
+    bind_name = '{0!s}{1:d}'.format(keyspace_col_name, i)
+    where_clause += '{0!s} < '.format(keyspace_col_name) + '%(' + bind_name + ')s'
     bind_vars[bind_name] = kr_max
   return where_clause, bind_vars

--- a/py/zk/zkocc.py
+++ b/py/zk/zkocc.py
@@ -54,7 +54,7 @@ class SimpleZkOccConnection(object):
     try:
       return self.client.call(method, req).reply
     except gorpc.GoRpcError as e:
-      raise ZkOccError('%s %s failed' % (method, req), e)
+      raise ZkOccError('{0!s} {1!s} failed'.format(method, req), e)
 
   # returns a ZkNode, see header
   def get(self, path):
@@ -133,7 +133,7 @@ class ZkOccConnection(object):
         pass
 
     self.simple_conn = None
-    raise ZkOccError("Cannot dial to any server, tried: %s" % addrs)
+    raise ZkOccError("Cannot dial to any server, tried: {0!s}".format(addrs))
 
   def close(self):
     if self.simple_conn:
@@ -153,7 +153,7 @@ class ZkOccConnection(object):
           attempt += 1
           logging.warning('zkocc: %s command failed %u times: %s', client_method, attempt, e)
           if attempt >= self.max_attempts:
-            raise ZkOccError('zkocc %s command failed %u times: %s' % (client_method, attempt, e))
+            raise ZkOccError('zkocc {0!s} command failed {1:d} times: {2!s}'.format(client_method, attempt, e))
 
           # try the next server if there is one, or retry our only server
           self.dial()

--- a/test/backup.py
+++ b/test/backup.py
@@ -87,7 +87,7 @@ class TestBackup(unittest.TestCase):
 
   def _insert_master(self, index):
     tablet_master.mquery('vt_test_keyspace',
-                         "insert into vt_insert_test (msg) values ('test %s')" % index, write=True)
+                         "insert into vt_insert_test (msg) values ('test {0!s}')".format(index), write=True)
 
   def test_backup(self):
     """test_backup will:

--- a/test/binlog.py
+++ b/test/binlog.py
@@ -146,8 +146,8 @@ def tearDownModule():
 
 
 def _get_update_stream(tblt):
-  return update_stream_service.UpdateStreamConnection('localhost:%u' %
-                                                      tblt.port, 30)
+  return update_stream_service.UpdateStreamConnection('localhost:{0:d}'.format(
+                                                      tblt.port), 30)
 
 
 class TestBinlog(unittest.TestCase):

--- a/test/custom_sharding.py
+++ b/test/custom_sharding.py
@@ -68,17 +68,17 @@ def tearDownModule():
 class TestCustomSharding(unittest.TestCase):
 
   def _insert_data(self, shard, start, count, table='data'):
-    sql = 'insert into %s(id, name) values (:id, :name)' % table
+    sql = 'insert into {0!s}(id, name) values (:id, :name)'.format(table)
     for x in xrange(count):
       bindvars = {
         'id':   start+x,
-        'name': 'row %u' % (start+x),
+        'name': 'row {0:d}'.format((start+x)),
         }
       utils.vtgate_execute_shard(vtgate_port, sql, 'test_keyspace', shard,
                                  bindvars=bindvars)
 
   def _check_data(self, shard, start, count, table='data'):
-    sql = 'select name from %s where id=:id' % table
+    sql = 'select name from {0!s} where id=:id'.format(table)
     for x in xrange(count):
       bindvars = {
         'id':   start+x,
@@ -89,7 +89,7 @@ class TestCustomSharding(unittest.TestCase):
       # vtctl_json will print the JSON-encoded version of QueryResult,
       # which is a []byte. That translates into a base64-endoded string.
       v = base64.b64decode(qr['Rows'][0][0])
-      self.assertEqual(v, 'row %u' % (start+x))
+      self.assertEqual(v, 'row {0:d}'.format((start+x)))
 
   def test_custom_end_to_end(self):
     """This test case runs through the common operations of a custom
@@ -212,8 +212,8 @@ primary key (id)
     self.assertEqual(len(rows), 20)
     expected = {}
     for i in xrange(10):
-     expected[100+i] = 'row %u' % (100+i)
-     expected[200+i] = 'row %u' % (200+i)
+     expected[100+i] = 'row {0:d}'.format((100+i))
+     expected[200+i] = 'row {0:d}'.format((200+i))
     self.assertEqual(rows, expected)
 
 if __name__ == '__main__':

--- a/test/environment.py
+++ b/test/environment.py
@@ -76,7 +76,7 @@ def reserve_ports(count):
 # simple run command, cannot use utils.run to avoid circular dependencies
 def run(args, raise_on_error=True, **kargs):
   try:
-    logging.debug("run: %s %s", str(args), ', '.join('%s=%s' % x for x in kargs.iteritems()))
+    logging.debug("run: %s %s", str(args), ', '.join('{0!s}={1!s}'.format(*x) for x in kargs.iteritems()))
     proc = subprocess.Popen(args,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,

--- a/test/framework.py
+++ b/test/framework.py
@@ -16,7 +16,7 @@ class TestCase(unittest.TestCase):
     cls.env = env
 
   def assertContains(self, b, a):
-    self.assertTrue(a in b, "%r not found in %r" % (a, b))
+    self.assertTrue(a in b, "{0!r} not found in {1!r}".format(a, b))
 
 class MultiDict(dict):
   def __getattr__(self, name):
@@ -93,10 +93,10 @@ def execute(cmd, trap_output=False, verbose=False, **kargs):
     kargs['stdout'] = PIPE
     kargs['stderr'] = PIPE
   if verbose:
-    print "Execute:", cmd, ', '.join('%s=%s' % x for x in kargs.iteritems())
+    print "Execute:", cmd, ', '.join('{0!s}={1!s}'.format(*x) for x in kargs.iteritems())
   proc = Popen(args, **kargs)
   proc.args = args
   stdout, stderr = proc.communicate()
   if proc.returncode:
-    raise Exception('FAIL: %s %s %s' % (args, stdout, stderr))
+    raise Exception('FAIL: {0!s} {1!s} {2!s}'.format(args, stdout, stderr))
   return stdout, stderr

--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -142,7 +142,7 @@ index by_msg (msg)
   def _insert_startup_value(self, tablet, table, id, msg):
     tablet.mquery('vt_test_keyspace', [
         'begin',
-        'insert into %s(id, msg) values(%u, "%s")' % (table, id, msg),
+        'insert into {0!s}(id, msg) values({1:d}, "{2!s}")'.format(table, id, msg),
         'commit'
         ], write=True)
 
@@ -166,15 +166,15 @@ index by_msg (msg)
     if keyspace_id_type == keyrange_constants.KIT_BYTES:
       k = base64.b64encode(pack_keyspace_id(keyspace_id))
     else:
-      k = "%u" % keyspace_id
+      k = "{0:d}".format(keyspace_id)
     tablet.mquery('vt_test_keyspace', [
         'begin',
-        'insert into %s(id, msg, keyspace_id) values(%u, "%s", 0x%x) /* EMD keyspace_id:%s user_id:%u */' % (table, id, msg, keyspace_id, k, id),
+        'insert into {0!s}(id, msg, keyspace_id) values({1:d}, "{2!s}", 0x{3:x}) /* EMD keyspace_id:{4!s} user_id:{5:d} */'.format(table, id, msg, keyspace_id, k, id),
         'commit'
         ], write=True)
 
   def _get_value(self, tablet, table, id):
-    return tablet.mquery('vt_test_keyspace', 'select id, msg, keyspace_id from %s where id=%u' % (table, id))
+    return tablet.mquery('vt_test_keyspace', 'select id, msg, keyspace_id from {0!s} where id={1:d}'.format(table, id))
 
   def _check_value(self, tablet, table, id, msg, keyspace_id,
                    should_be_here=True):
@@ -238,21 +238,21 @@ index by_msg (msg)
   def _insert_lots(self, count, base=0):
     for i in xrange(count):
       self._insert_value(shard_master, 'resharding1', 10000 + base + i,
-                         'msg-range1-%u' % i, 0xA000000000000000 + base + i)
+                         'msg-range1-{0:d}'.format(i), 0xA000000000000000 + base + i)
       self._insert_value(shard_master, 'resharding1', 20000 + base + i,
-                         'msg-range2-%u' % i, 0xE000000000000000 + base + i)
+                         'msg-range2-{0:d}'.format(i), 0xE000000000000000 + base + i)
 
   # _check_lots returns how many of the values we have, in percents.
   def _check_lots(self, count, base=0):
     found = 0
     for i in xrange(count):
       if self._is_value_present_and_correct(shard_1_replica, 'resharding1',
-                                            10000 + base + i, 'msg-range1-%u' %
-                                            i, 0xA000000000000000 + base + i):
+                                            10000 + base + i, 'msg-range1-{0:d}'.format(
+                                            i), 0xA000000000000000 + base + i):
         found += 1
       if self._is_value_present_and_correct(shard_1_replica, 'resharding1',
-                                            20000 + base + i, 'msg-range2-%u' %
-                                            i, 0xE000000000000000 + base + i):
+                                            20000 + base + i, 'msg-range2-{0:d}'.format(
+                                            i), 0xE000000000000000 + base + i):
         found += 1
     percent = found * 100 / count / 2
     logging.debug("I have %u%% of the data", percent)
@@ -270,10 +270,10 @@ index by_msg (msg)
     found = 0
     for i in xrange(count):
       self._check_value(shard_0_replica, 'resharding1', 10000 + base + i,
-                        'msg-range1-%u' % i, 0xA000000000000000 + base + i,
+                        'msg-range1-{0:d}'.format(i), 0xA000000000000000 + base + i,
                         should_be_here=False)
       self._check_value(shard_0_replica, 'resharding1', 20000 + base + i,
-                        'msg-range2-%u' % i, 0xE000000000000000 + base + i,
+                        'msg-range2-{0:d}'.format(i), 0xE000000000000000 + base + i,
                         should_be_here=False)
 
   def test_resharding(self):

--- a/test/java_vtgate_test_helper.py
+++ b/test/java_vtgate_test_helper.py
@@ -88,7 +88,7 @@ class TestEnv(object):
         else:
           utils.run_vtctl(['ApplyVSchema', "-vschema_file", self.vschema])
       self.vtgate_server, self.vtgate_port = utils.vtgate_start(cache_ttl='500s', vtport=self.vtgate_port)
-      vtgate_client = zkocc.ZkOccConnection("localhost:%u" % self.vtgate_port, "test_nj", 30.0)
+      vtgate_client = zkocc.ZkOccConnection("localhost:{0:d}".format(self.vtgate_port), "test_nj", 30.0)
       topology.read_topology(vtgate_client)
     except:
       self.shutdown()

--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -135,9 +135,9 @@ def setup_sharded_keyspace():
   for t in [shard_0_master, shard_0_replica, shard_1_master, shard_1_replica]:
     t.wait_for_vttablet_state('SERVING')
 
-  utils.run_vtctl(['InitShardMaster', '%s/-80' % SHARDED_KEYSPACE,
+  utils.run_vtctl(['InitShardMaster', '{0!s}/-80'.format(SHARDED_KEYSPACE),
                    shard_0_master.tablet_alias], auto_log=True)
-  utils.run_vtctl(['InitShardMaster', '%s/80-' % SHARDED_KEYSPACE,
+  utils.run_vtctl(['InitShardMaster', '{0!s}/80-'.format(SHARDED_KEYSPACE),
                    shard_1_master.tablet_alias], auto_log=True)
 
   utils.run_vtctl(['RebuildKeyspaceGraph', SHARDED_KEYSPACE],
@@ -166,7 +166,7 @@ def setup_unsharded_keyspace():
   for t in [unsharded_master, unsharded_replica]:
     t.wait_for_vttablet_state('SERVING')
 
-  utils.run_vtctl(['InitShardMaster', '%s/0' % UNSHARDED_KEYSPACE,
+  utils.run_vtctl(['InitShardMaster', '{0!s}/0'.format(UNSHARDED_KEYSPACE),
                    unsharded_master.tablet_alias], auto_log=True)
 
   utils.run_vtctl(['RebuildKeyspaceGraph', UNSHARDED_KEYSPACE],
@@ -183,7 +183,7 @@ ALL_DB_TYPES = ['master', 'rdonly', 'replica']
 class TestKeyspace(unittest.TestCase):
   def _read_keyspace(self, keyspace_name):
     global vtgate_port
-    vtgate_client = zkocc.ZkOccConnection("localhost:%u" % vtgate_port,
+    vtgate_client = zkocc.ZkOccConnection("localhost:{0:d}".format(vtgate_port),
                                           "test_nj", 30.0)
     return keyspace.read_keyspace(vtgate_client, keyspace_name)
 

--- a/test/keyspace_util.py
+++ b/test/keyspace_util.py
@@ -72,9 +72,9 @@ class TestEnv(object):
     t = tablet.Tablet()
     self.tablets.append(t)
     if tablet_type == "master":
-      key = "%s.%s.%s" %(keyspace, shard, tablet_type)
+      key = "{0!s}.{1!s}.{2!s}".format(keyspace, shard, tablet_type)
     else:
-      key = "%s.%s.%s.%s" %(keyspace, shard, tablet_type, index)
+      key = "{0!s}.{1!s}.{2!s}.{3!s}".format(keyspace, shard, tablet_type, index)
     self.tablet_map[key] = t
     proc = t.init_mysql()
     t.init_tablet(tablet_type, keyspace=keyspace, shard=shard)

--- a/test/mysql_flavor.py
+++ b/test/mysql_flavor.py
@@ -103,7 +103,7 @@ class MariaDB(MysqlFlavor):
 
   def change_master_commands(self, host, port, pos):
     return [
-        "SET GLOBAL gtid_slave_pos = '%s'" % pos["MariaDB"],
+        "SET GLOBAL gtid_slave_pos = '{0!s}'".format(pos["MariaDB"]),
         "CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%u, "
         "MASTER_USER='vt_repl', MASTER_USE_GTID = slave_pos" %
         (host, port)]
@@ -149,7 +149,7 @@ class MySQL56(MysqlFlavor):
   def change_master_commands(self, host, port, pos):
     return [
         "RESET MASTER",
-        "SET GLOBAL gtid_purged = '%s'" % pos["MySQL56"],
+        "SET GLOBAL gtid_purged = '{0!s}'".format(pos["MySQL56"]),
         "CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%u, "
         "MASTER_USER='vt_repl', MASTER_AUTO_POSITION = 1" %
         (host, port)]

--- a/test/queryservice_test.py
+++ b/test/queryservice_test.py
@@ -63,7 +63,7 @@ def run_tests(options, args):
   try:
     env.memcache = options.memcache
     env.setUp()
-    print "Starting queryservice_test.py: %s" % options.env
+    print "Starting queryservice_test.py: {0!s}".format(options.env)
     sys.stdout.flush()
     framework.TestCase.setenv(env)
     result = unittest.TextTestRunner(verbosity=options.verbose, failfast=True).run(suite)

--- a/test/queryservice_tests/cache_tests.py
+++ b/test/queryservice_tests/cache_tests.py
@@ -234,12 +234,12 @@ class TestCache(framework.TestCase):
   def test_cache1_sqls(self):
     error_count = self.env.run_cases(cache_cases1.cases)
     if error_count != 0:
-      self.fail("test_cache1_sqls errors: %d" % error_count)
+      self.fail("test_cache1_sqls errors: {0:d}".format(error_count))
 
   def test_cache2_sqls(self):
     error_count = self.env.run_cases(cache_cases2.cases)
     if error_count != 0:
-      self.fail("test_cache2_sqls errors: %d" % error_count)
+      self.fail("test_cache2_sqls errors: {0:d}".format(error_count))
 
   def _get_vars_table_stats(self, table_stats, table, stats):
     return table_stats[table + "." + stats]

--- a/test/queryservice_tests/cases_framework.py
+++ b/test/queryservice_tests/cases_framework.py
@@ -45,7 +45,7 @@ class Log(object):
        self.cache_invalidations,
        self.error) = line.strip().split('\t')
     except ValueError:
-      print "Wrong looking line: %r" % line
+      print "Wrong looking line: {0!r}".format(line)
       raise
 
   def check(self, case):
@@ -68,7 +68,7 @@ class Log(object):
     return failures
 
   def fail(self, reason, should, is_):
-    return "FAIL: %s: %r != %r" % (reason, should, is_)
+    return "FAIL: {0!s}: {1!r} != {2!r}".format(reason, should, is_)
 
   def check_original_sql(self, case):
     # The following is necessary because Python and Go use different
@@ -163,7 +163,7 @@ class Case(object):
     if self.result is not None:
       result = list(cursor)
       if self.result != result:
-        failures.append("%r:\n%s !=\n%s" % (self.sql, self.result, result))
+        failures.append("{0!r}:\n{1!s} !=\n{2!s}".format(self.sql, self.result, result))
     for i in range(30):
       lines = env.querylog.tailer.readLines()
       if not lines:
@@ -178,16 +178,16 @@ class Case(object):
     if self.is_testing_cache:
       tdelta = self.table_stats_delta(tstart, env)
       if self.cache_hits is not None and tdelta['Hits'] != self.cache_hits:
-        failures.append("Bad Cache Hits: %s != %s" % (self.cache_hits, tdelta['Hits']))
+        failures.append("Bad Cache Hits: {0!s} != {1!s}".format(self.cache_hits, tdelta['Hits']))
 
       if self.cache_absent is not None and tdelta['Absent'] != self.cache_absent:
-        failures.append("Bad Cache Absent: %s != %s" % (self.cache_absent, tdelta['Absent']))
+        failures.append("Bad Cache Absent: {0!s} != {1!s}".format(self.cache_absent, tdelta['Absent']))
 
       if self.cache_misses is not None and tdelta['Misses'] != self.cache_misses:
-        failures.append("Bad Cache Misses: %s != %s" % (self.cache_misses, tdelta['Misses']))
+        failures.append("Bad Cache Misses: {0!s} != {1!s}".format(self.cache_misses, tdelta['Misses']))
 
       if self.cache_invalidations is not None and tdelta['Invalidations'] != self.cache_invalidations:
-        failures.append("Bad Cache Invalidations: %s != %s" % (self.cache_invalidations, tdelta['Invalidations']))
+        failures.append("Bad Cache Invalidations: {0!s} != {1!s}".format(self.cache_invalidations, tdelta['Invalidations']))
 
     return failures
 
@@ -202,7 +202,7 @@ class Case(object):
     return env.http_get('/debug/table_stats')[self.cache_table]
 
   def __str__(self):
-    return "Case %r" % self.doc
+    return "Case {0!r}".format(self.doc)
 
 
 class MultiCase(object):
@@ -227,4 +227,4 @@ class MultiCase(object):
     return iter(self.sqls_and_cases)
 
   def __str__(self):
-    return "MultiCase: %s" % self.doc
+    return "MultiCase: {0!s}".format(self.doc)

--- a/test/queryservice_tests/nocache_tests.py
+++ b/test/queryservice_tests/nocache_tests.py
@@ -168,7 +168,7 @@ class TestNocache(framework.TestCase):
   def test_select_lock(self):
     for lock_mode in ['for update', 'lock in share mode']:
       try:
-        self.env.execute("select * from vtocc_test where intval=2 %s" % lock_mode)
+        self.env.execute("select * from vtocc_test where intval=2 {0!s}".format(lock_mode))
       except dbexceptions.DatabaseError as e:
         self.assertContains(str(e), "error: Disallowed")
       else:
@@ -176,7 +176,7 @@ class TestNocache(framework.TestCase):
 
       # If these throw no exceptions, we're good
       self.env.conn.begin()
-      self.env.execute("select * from vtocc_test where intval=2 %s" % lock_mode)
+      self.env.execute("select * from vtocc_test where intval=2 {0!s}".format(lock_mode))
       self.env.conn.commit()
       # Make sure the row is not locked for read
       self.env.execute("select * from vtocc_test where intval=2")
@@ -546,12 +546,12 @@ class TestNocache(framework.TestCase):
       self.assertEqual(stat["ErrorCount"], errors)
       self.assertTrue(stat["Time"] > 0)
       return
-    self.fail("query %s not found" % query)
+    self.fail("query {0!s} not found".format(query))
 
   def test_sqls(self):
     error_count = self.env.run_cases(nocache_cases.cases)
     if error_count != 0:
-      self.fail("test_execution errors: %d"%(error_count))
+      self.fail("test_execution errors: {0:d}".format((error_count)))
 
   def test_table_acl_no_access(self):
     with self.assertRaisesRegexp(dbexceptions.DatabaseError, '.*table acl error.*'):

--- a/test/queryservice_tests/stream_tests.py
+++ b/test/queryservice_tests/stream_tests.py
@@ -114,10 +114,10 @@ class TestStream(framework.TestCase):
         cu.fetchall()
       errMsg1 = "error: the query was killed either because it timed out or was canceled: Lost connectioy to MySQL server during query (errno 2013)"
       errMsg2 = "error: Query execution was interrupted (errno 1317)"
-      self.assertTrue(cm.exception not in (errMsg1, errMsg2), "did not raise interruption error: %s" % str(cm.exception))
+      self.assertTrue(cm.exception not in (errMsg1, errMsg2), "did not raise interruption error: {0!s}".format(str(cm.exception)))
       cu.close()
     except Exception, e:
-      self.fail("Failed with error %s %s" % (str(e), traceback.print_exc()))
+      self.fail("Failed with error {0!s} {1!s}".format(str(e), traceback.print_exc()))
 
   def _populate_vtocc_big_table(self, num_rows):
       self.env.conn.begin()
@@ -153,7 +153,7 @@ class TestStream(framework.TestCase):
         streaming_queries = json.loads(content)
         retries -= 1
         if retries == 0:
-            self.fail("unable to fetch streaming queries from %s" % streamqueryz_url)
+            self.fail("unable to fetch streaming queries from {0!s}".format(streamqueryz_url))
         else:
             time.sleep(1) 
       connId = streaming_queries[0]['ConnID']

--- a/test/queryservice_tests/test_env.py
+++ b/test/queryservice_tests/test_env.py
@@ -51,7 +51,7 @@ class TestEnv(object):
 
   @property
   def address(self):
-    return "localhost:%s" % self.port
+    return "localhost:{0!s}".format(self.port)
 
   def connect(self):
     c = tablet_conn.connect(self.address, '', 'test_keyspace', '0', 2, user='youtube-dev-dedicated', password='vtpass')
@@ -70,7 +70,7 @@ class TestEnv(object):
     return curs
 
   def url(self, path):
-    return "http://localhost:%s/" % (self.port) + path
+    return "http://localhost:{0!s}/".format((self.port)) + path
 
   def http_get(self, path, use_json=True):
     data = urllib2.urlopen(self.url(path)).read()
@@ -244,7 +244,7 @@ class TestEnv(object):
     self.conn = self.connect()
     self.txlogger = utils.curl(self.url('/debug/txlog'), background=True, stdout=open(self.txlog_file, 'w'))
     self.txlog = framework.Tailer(self.txlog_file, flush=self.tablet.flush)
-    self.log = framework.Tailer(os.path.join(environment.vtlogroot, '%s.INFO' % self.env), flush=self.tablet.flush)
+    self.log = framework.Tailer(os.path.join(environment.vtlogroot, '{0!s}.INFO'.format(self.env)), flush=self.tablet.flush)
     self.querylog = Querylog(self)
 
   def tearDown(self):

--- a/test/schema.py
+++ b/test/schema.py
@@ -136,13 +136,12 @@ class TestSchema(unittest.TestCase):
   def _check_tables(self, tablet, expectedCount):
     tables = tablet.mquery(db_name, 'show tables')
     self.assertEqual(len(tables), expectedCount,
-                     'Unexpected table count on %s (not %u): %s' %
-                     (tablet.tablet_alias, expectedCount, str(tables)))
+                     'Unexpected table count on {0!s} (not {1:d}): {2!s}'.format(tablet.tablet_alias, expectedCount, str(tables)))
 
   def _check_db_not_created(self, tablet):
     # Broadly catch all exceptions, since the exception being raised is internal to MySQL.
     # We're strictly checking the error message though, so should be fine.
-    with self.assertRaisesRegexp(Exception, '(1049, "Unknown database \'%s\'")' % db_name):
+    with self.assertRaisesRegexp(Exception, '(1049, "Unknown database \'{0!s}\'")'.format(db_name)):
       tables = tablet.mquery(db_name, 'show tables')
 
   def _apply_schema(self, keyspace, sql):
@@ -165,19 +164,19 @@ class TestSchema(unittest.TestCase):
     return out
 
   def _create_test_table_sql(self, table):
-    return 'CREATE TABLE %s ( \
+    return 'CREATE TABLE {0!s} ( \
             `id` BIGINT(20) not NULL, \
             `msg` varchar(64), \
             PRIMARY KEY (`id`) \
-            ) ENGINE=InnoDB' % table
+            ) ENGINE=InnoDB'.format(table)
 
   def _alter_test_table_sql(self, table, index_column_name):
-    return 'ALTER TABLE %s \
+    return 'ALTER TABLE {0!s} \
             ADD COLUMN new_id bigint(20) NOT NULL AUTO_INCREMENT FIRST, \
             DROP PRIMARY KEY, \
             ADD PRIMARY KEY (new_id), \
-            ADD INDEX idx_column(%s) \
-            ' % (table, index_column_name)
+            ADD INDEX idx_column({1!s}) \
+            '.format(table, index_column_name)
 
   def test_schema_changes(self):
     schema_changes = ';'.join([

--- a/test/secure.py
+++ b/test/secure.py
@@ -31,7 +31,7 @@ cert_dir = environment.tmproot + "/certs"
 def openssl(cmd):
   result = subprocess.call(["openssl"] + cmd, stderr=utils.devnull)
   if result != 0:
-    raise utils.TestError("OpenSSL command failed: %s" % " ".join(cmd))
+    raise utils.TestError("OpenSSL command failed: {0!s}".format(" ".join(cmd)))
 
 def setUpModule():
   try:
@@ -252,49 +252,49 @@ class TestSecure(unittest.TestCase):
                      shard_0_master.tablet_alias], auto_log=True)
 
     # then get the topology and check it
-    topo_client = zkocc.ZkOccConnection("localhost:%u" % vtgate_port,
+    topo_client = zkocc.ZkOccConnection("localhost:{0:d}".format(vtgate_port),
                                         "test_nj", 30.0)
     topology.read_keyspaces(topo_client)
 
     shard_0_master_addrs = topology.get_host_port_by_name(topo_client, "test_keyspace.0.master:vts")
     if len(shard_0_master_addrs) != 1:
-      self.fail('topology.get_host_port_by_name failed for "test_keyspace.0.master:vts", got: %s' % " ".join(["%s:%u(%s)" % (h, p, str(e)) for (h, p, e) in shard_0_master_addrs]))
+      self.fail('topology.get_host_port_by_name failed for "test_keyspace.0.master:vts", got: {0!s}'.format(" ".join(["{0!s}:{1:d}({2!s})".format(h, p, str(e)) for (h, p, e) in shard_0_master_addrs])))
     if shard_0_master_addrs[0][2] != True:
       self.fail('topology.get_host_port_by_name failed for "test_keyspace.0.master:vts" is not encrypted')
-    logging.debug("shard 0 master addrs: %s", " ".join(["%s:%u(%s)" % (h, p, str(e)) for (h, p, e) in shard_0_master_addrs]))
+    logging.debug("shard 0 master addrs: %s", " ".join(["{0!s}:{1:d}({2!s})".format(h, p, str(e)) for (h, p, e) in shard_0_master_addrs]))
 
     # make sure asking for optionally secure connections works too
     auto_addrs = topology.get_host_port_by_name(topo_client, "test_keyspace.0.master:vt", encrypted=True)
     if auto_addrs != shard_0_master_addrs:
-      self.fail('topology.get_host_port_by_name doesn\'t resolve encrypted addresses properly: %s != %s' % (str(shard_0_master_addrs), str(auto_addrs)))
+      self.fail('topology.get_host_port_by_name doesn\'t resolve encrypted addresses properly: {0!s} != {1!s}'.format(str(shard_0_master_addrs), str(auto_addrs)))
 
     # try to connect with regular client
     try:
-      conn = tablet3.TabletConnection("%s:%u" % (shard_0_master_addrs[0][0], shard_0_master_addrs[0][1]),
+      conn = tablet3.TabletConnection("{0!s}:{1:d}".format(shard_0_master_addrs[0][0], shard_0_master_addrs[0][1]),
                                       "", "test_keyspace", "0", 10.0)
       conn.dial()
       self.fail("No exception raised to secure port")
     except dbexceptions.FatalError as e:
       if not e.args[0][0].startswith('Unexpected EOF in handshake to'):
-        self.fail("Unexpected exception: %s" % str(e))
+        self.fail("Unexpected exception: {0!s}".format(str(e)))
 
     sconn = utils.get_vars(shard_0_master.port)["SecureConnections"]
     if sconn != 0:
-      self.fail("unexpected conns %s" % sconn)
+      self.fail("unexpected conns {0!s}".format(sconn))
 
     # connect to encrypted port
-    conn = tablet3.TabletConnection("%s:%u" % (shard_0_master_addrs[0][0], shard_0_master_addrs[0][1]),
+    conn = tablet3.TabletConnection("{0!s}:{1:d}".format(shard_0_master_addrs[0][0], shard_0_master_addrs[0][1]),
                                     "", "test_keyspace", "0", 5.0, encrypted=True)
     conn.dial()
     (results, rowcount, lastrowid, fields) = conn._execute("select 1 from dual", {})
-    self.assertEqual(results, [(1,),], 'wrong conn._execute output: %s' % str(results))
+    self.assertEqual(results, [(1,),], 'wrong conn._execute output: {0!s}'.format(str(results)))
 
     sconn = utils.get_vars(shard_0_master.port)["SecureConnections"]
     if sconn != 1:
-      self.fail("unexpected conns %s" % sconn)
+      self.fail("unexpected conns {0!s}".format(sconn))
     saccept = utils.get_vars(shard_0_master.port)["SecureAccepts"]
     if saccept == 0:
-      self.fail("unexpected accepts %s" % saccept)
+      self.fail("unexpected accepts {0!s}".format(saccept))
 
     # trigger a time out on a secure connection, see what exception we get
     try:
@@ -312,7 +312,7 @@ class TestSecure(unittest.TestCase):
     # try to connect to vtgate with regular client
     timeout = 2.0
     try:
-      conn = vtgatev2.connect(["localhost:%s" % (gate_secure_port),],
+      conn = vtgatev2.connect(["localhost:{0!s}".format((gate_secure_port)),],
                                timeout)
       self.fail("No exception raised to VTGate secure port")
     except dbexceptions.OperationalError as e:
@@ -321,14 +321,14 @@ class TestSecure(unittest.TestCase):
       self.assertIsInstance(exception_type, dbexceptions.FatalError,
                             "unexpected exception type")
       if not exception_msg.startswith('Unexpected EOF in handshake to'):
-        self.fail("Unexpected exception message: %s" % exception_msg)
+        self.fail("Unexpected exception message: {0!s}".format(exception_msg))
 
     sconn = utils.get_vars(gate_port)["SecureConnections"]
     if sconn != 0:
-      self.fail("unexpected conns %s" % sconn)
+      self.fail("unexpected conns {0!s}".format(sconn))
 
     # connect to vtgate with encrypted port
-    conn = vtgatev2.connect(["localhost:%s" % (gate_secure_port),],
+    conn = vtgatev2.connect(["localhost:{0!s}".format((gate_secure_port)),],
                              timeout, encrypted=True)
     (results, rowcount, lastrowid, fields) = conn._execute(
         "select 1 from dual",
@@ -336,16 +336,16 @@ class TestSecure(unittest.TestCase):
         "test_keyspace",
         "master",
         keyranges=[keyrange.KeyRange(keyrange_constants.NON_PARTIAL_KEYRANGE),])
-    self.assertEqual(rowcount, 1, "want 1, got %d" % (rowcount))
-    self.assertEqual(len(fields), 1, "want 1, got %d" % (len(fields)))
-    self.assertEqual(results, [(1,),], 'wrong conn._execute output: %s' % str(results))
+    self.assertEqual(rowcount, 1, "want 1, got {0:d}".format((rowcount)))
+    self.assertEqual(len(fields), 1, "want 1, got {0:d}".format((len(fields))))
+    self.assertEqual(results, [(1,),], 'wrong conn._execute output: {0!s}'.format(str(results)))
 
     sconn = utils.get_vars(gate_port)["SecureConnections"]
     if sconn != 1:
-      self.fail("unexpected conns %s" % sconn)
+      self.fail("unexpected conns {0!s}".format(sconn))
     saccept = utils.get_vars(gate_port)["SecureAccepts"]
     if saccept == 0:
-      self.fail("unexpected accepts %s" % saccept)
+      self.fail("unexpected accepts {0!s}".format(saccept))
 
     # trigger a time out on a vtgate secure connection, see what exception we get
     try:

--- a/test/sharded.py
+++ b/test/sharded.py
@@ -130,7 +130,7 @@ class TestSharded(unittest.TestCase):
     # make sure the '1' value was written on first shard
     rows = shard_0_master.mquery('vt_test_keyspace', "select id, msg from vt_select_test order by id")
     self.assertEqual(rows, ((1, 'test 1'), ),
-                     'wrong mysql_query output: %s' % str(rows))
+                     'wrong mysql_query output: {0!s}'.format(str(rows)))
 
     utils.pause("After db writes")
 
@@ -166,43 +166,43 @@ class TestSharded(unittest.TestCase):
           for sub_path in ['', '.vdns', '/0', '/vt.vdns']:
             expected = '/zk/test_nj/zkns/vt/test_keyspace/' + base + '/' + db_type + sub_path
             if expected not in lines:
-              self.fail('missing zkns part:\n%s\nin:%s' %(expected, out))
+              self.fail('missing zkns part:\n{0!s}\nin:{1!s}'.format(expected, out))
 
     # now try to connect using the python client and shard-aware connection
     # to both shards
     # first get the topology and check it
-    vtgate_client = zkocc.ZkOccConnection("localhost:%u" % vtgate_port,
+    vtgate_client = zkocc.ZkOccConnection("localhost:{0:d}".format(vtgate_port),
                                           "test_nj", 30.0)
     topology.read_keyspaces(vtgate_client)
 
     shard_0_master_addrs = topology.get_host_port_by_name(vtgate_client, "test_keyspace.-80.master:vt")
     if len(shard_0_master_addrs) != 1:
-      self.fail('topology.get_host_port_by_name failed for "test_keyspace.-80.master:vt", got: %s' % " ".join(["%s:%u(%s)" % (h, p, str(e)) for (h, p, e) in shard_0_master_addrs]))
-    logging.debug("shard 0 master addrs: %s", " ".join(["%s:%u(%s)" % (h, p, str(e)) for (h, p, e) in shard_0_master_addrs]))
+      self.fail('topology.get_host_port_by_name failed for "test_keyspace.-80.master:vt", got: {0!s}'.format(" ".join(["{0!s}:{1:d}({2!s})".format(h, p, str(e)) for (h, p, e) in shard_0_master_addrs])))
+    logging.debug("shard 0 master addrs: %s", " ".join(["{0!s}:{1:d}({2!s})".format(h, p, str(e)) for (h, p, e) in shard_0_master_addrs]))
 
     # connect to shard -80
-    conn = tablet3.TabletConnection("%s:%u" % (shard_0_master_addrs[0][0],
+    conn = tablet3.TabletConnection("{0!s}:{1:d}".format(shard_0_master_addrs[0][0],
                                                shard_0_master_addrs[0][1]),
                                     "", "test_keyspace", "-80", 10.0)
     conn.dial()
     (results, rowcount, lastrowid, fields) = conn._execute("select id, msg from vt_select_test order by id", {})
     self.assertEqual(results, [(1, 'test 1'), ],
-                     'wrong conn._execute output: %s' % str(results))
+                     'wrong conn._execute output: {0!s}'.format(str(results)))
 
     # connect to shard 80-
     shard_1_master_addrs = topology.get_host_port_by_name(vtgate_client, "test_keyspace.80-.master:vt")
-    conn = tablet3.TabletConnection("%s:%u" % (shard_1_master_addrs[0][0],
+    conn = tablet3.TabletConnection("{0!s}:{1:d}".format(shard_1_master_addrs[0][0],
                                                shard_1_master_addrs[0][1]),
                                     "", "test_keyspace", "80-", 10.0)
     conn.dial()
     (results, rowcount, lastrowid, fields) = conn._execute("select id, msg from vt_select_test order by id", {})
     self.assertEqual(results, [(10, 'test 10'), ],
-                     'wrong conn._execute output: %s' % str(results))
+                     'wrong conn._execute output: {0!s}'.format(str(results)))
     vtgate_client.close()
 
     # try to connect with bad shard
     try:
-      conn = tablet3.TabletConnection("localhost:%u" % shard_0_master.port,
+      conn = tablet3.TabletConnection("localhost:{0:d}".format(shard_0_master.port),
                                       "", "test_keyspace", "-90", 10.0)
       conn.dial()
       self.fail('expected an exception')

--- a/test/topo_flavor/etcd.py
+++ b/test/topo_flavor/etcd.py
@@ -23,9 +23,9 @@ class EtcdCluster:
     self.hostname = 'localhost'
     self.client_port = self.port_base
     self.peer_port = self.port_base + 1
-    self.client_addr = '%s:%u' % (self.hostname, self.client_port)
-    self.peer_addr = '%s:%u' % (self.hostname, self.peer_port)
-    self.api_url = 'http://%s/v2' % (self.client_addr)
+    self.client_addr = '{0!s}:{1:d}'.format(self.hostname, self.client_port)
+    self.peer_addr = '{0!s}:{1:d}'.format(self.hostname, self.peer_port)
+    self.api_url = 'http://{0!s}/v2'.format((self.client_addr))
 
     dirname = 'etcd_' + self.name
     self.data_dir = os.path.join(environment.vtdataroot, dirname)
@@ -64,8 +64,7 @@ class EtcdTopoServer(server.TopoServer):
     for cell, cluster in self.clusters.iteritems():
       if cell != 'global':
         utils.curl(
-            '%s/keys/vt/cells/%s' %
-            (self.clusters['global'].api_url, cell), request='PUT',
+            '{0!s}/keys/vt/cells/{1!s}'.format(self.clusters['global'].api_url, cell), request='PUT',
             data='value=http://' + cluster.client_addr)
 
   def teardown(self):

--- a/test/topo_flavor/zookeeper.py
+++ b/test/topo_flavor/zookeeper.py
@@ -37,18 +37,18 @@ class ZkTopoServer(server.TopoServer):
     self.assign_ports()
     run(binary_args('zkctl') + [
         '-log_dir', vtlogroot,
-        '-zk.cfg', '1@%s:%s' % (self.hostname, self.zk_ports),
+        '-zk.cfg', '1@{0!s}:{1!s}'.format(self.hostname, self.zk_ports),
         'init'])
     config = tmproot + '/test-zk-client-conf.json'
     with open(config, 'w') as f:
-      ca_server = 'localhost:%u' % (self.zk_client_port)
+      ca_server = 'localhost:{0:d}'.format((self.zk_client_port))
       if add_bad_host:
         ca_server += ',does.not.exists:1234'
       zk_cell_mapping = {
-          'test_nj': 'localhost:%u' % (self.zk_client_port),
-          'test_ny': 'localhost:%u' % (self.zk_client_port),
+          'test_nj': 'localhost:{0:d}'.format((self.zk_client_port)),
+          'test_ny': 'localhost:{0:d}'.format((self.zk_client_port)),
           'test_ca': ca_server,
-          'global': 'localhost:%u' % (self.zk_client_port),
+          'global': 'localhost:{0:d}'.format((self.zk_client_port)),
       }
       json.dump(zk_cell_mapping, f)
     os.environ['ZK_CLIENT_CONFIG'] = config
@@ -64,7 +64,7 @@ class ZkTopoServer(server.TopoServer):
     self.assign_ports()
     run(binary_args('zkctl') + [
         '-log_dir', vtlogroot,
-        '-zk.cfg', '1@%s:%s' % (self.hostname, self.zk_ports),
+        '-zk.cfg', '1@{0!s}:{1!s}'.format(self.hostname, self.zk_ports),
         'shutdown' if utils.options.keep_logs else 'teardown'],
         raise_on_error=False)
 

--- a/test/vertical_split_vtgate.py
+++ b/test/vertical_split_vtgate.py
@@ -29,7 +29,7 @@ class TestVerticalSplitVTGate(vertical_split.TestVerticalSplit):
     cursor = conn.cursor(keyspace, db_type, keyranges=[keyrange.KeyRange(keyrange_constants.NON_PARTIAL_KEYRANGE)], writable=True)
     for i in xrange(count):
       conn.begin()
-      cursor.execute("insert into %s (id, msg) values(%u, 'value %u')" % (
+      cursor.execute("insert into {0!s} (id, msg) values({1:d}, 'value {2:d}')".format(
           table, self.insert_index, self.insert_index), {})
       conn.commit()
       self.insert_index += 1
@@ -44,23 +44,23 @@ class TestVerticalSplitVTGate(vertical_split.TestVerticalSplit):
     for db_type in servedfrom_db_types:
       for tbl in moved_tables:
         try:
-          rows = conn._execute("select * from %s" % tbl, {}, destination_ks, db_type, keyranges=[keyrange.KeyRange(keyrange_constants.NON_PARTIAL_KEYRANGE)])
-          logging.debug("Select on %s.%s returned %d rows" % (db_type, tbl, len(rows)))
+          rows = conn._execute("select * from {0!s}".format(tbl), {}, destination_ks, db_type, keyranges=[keyrange.KeyRange(keyrange_constants.NON_PARTIAL_KEYRANGE)])
+          logging.debug("Select on {0!s}.{1!s} returned {2:d} rows".format(db_type, tbl, len(rows)))
         except Exception, e:
-          self.fail("Execute failed w/ exception %s" % str(e))
+          self.fail("Execute failed w/ exception {0!s}".format(str(e)))
 
   def _check_stats(self):
     v = utils.get_vars(self.vtgate_port)
-    self.assertEqual(v['VttabletCall']['Histograms']['Execute.source_keyspace.0.replica']['Count'], 2, "unexpected value for VttabletCall(Execute.source_keyspace.0.replica) inside %s" % str(v))
-    self.assertEqual(v['VtgateApi']['Histograms']['ExecuteKeyRanges.destination_keyspace.master']['Count'], 6, "unexpected value for VtgateApi(ExecuteKeyRanges.destination_keyspace.master) inside %s" % str(v))
-    self.assertEqual(len(v['VtgateApiErrorCounts']), 0, "unexpected errors for VtgateApiErrorCounts inside %s" % str(v))
+    self.assertEqual(v['VttabletCall']['Histograms']['Execute.source_keyspace.0.replica']['Count'], 2, "unexpected value for VttabletCall(Execute.source_keyspace.0.replica) inside {0!s}".format(str(v)))
+    self.assertEqual(v['VtgateApi']['Histograms']['ExecuteKeyRanges.destination_keyspace.master']['Count'], 6, "unexpected value for VtgateApi(ExecuteKeyRanges.destination_keyspace.master) inside {0!s}".format(str(v)))
+    self.assertEqual(len(v['VtgateApiErrorCounts']), 0, "unexpected errors for VtgateApiErrorCounts inside {0!s}".format(str(v)))
     self.assertEqual(
             v['ResilientSrvTopoServerEndPointsReturnedCount']['test_nj.source_keyspace.0.master'] /
               v['ResilientSrvTopoServerEndPointQueryCount']['test_nj.source_keyspace.0.master'],
-            1, "unexpected EndPointsReturnedCount inside %s" % str(v))
+            1, "unexpected EndPointsReturnedCount inside {0!s}".format(str(v)))
     self.assertNotIn(
             'test_nj.source_keyspace.0.master', v['ResilientSrvTopoServerEndPointDegradedResultCount'],
-            "unexpected EndPointDegradedResultCount inside %s" % str(v))
+            "unexpected EndPointDegradedResultCount inside {0!s}".format(str(v)))
 
 if __name__ == '__main__':
   vertical_split.client_type = vertical_split.VTGATE

--- a/test/vtctld_test.py
+++ b/test/vtctld_test.py
@@ -136,7 +136,7 @@ class TestVtctld(unittest.TestCase):
       line_map[alias] = parts
     for tablet in tablets:
       if not tablet.tablet_alias in line_map:
-         self.assertFalse('tablet %s is not in the result: %s' % (
+         self.assertFalse('tablet {0!s} is not in the result: {1!s}'.format(
                           tablet.tablet_alias, str(line_map)))
 
   def test_vtctl(self):
@@ -169,7 +169,7 @@ class TestVtctld(unittest.TestCase):
     self.assertEqual(len(self.data["Scrap"]), 1)
 
   def test_partial(self):
-    utils.pause("You can now run a browser and connect to http://%s:%u to manually check topology" % (socket.getfqdn(), utils.vtctld.port))
+    utils.pause("You can now run a browser and connect to http://{0!s}:{1:d} to manually check topology".format(socket.getfqdn(), utils.vtctld.port))
     self.assertEqual(self.data["Partial"], True)
 
   def test_explorer_redirects(self):
@@ -178,12 +178,12 @@ class TestVtctld(unittest.TestCase):
                    environment.topo_server().flavor())
       return
 
-    base = 'http://localhost:%u' % utils.vtctld.port
+    base = 'http://localhost:{0:d}'.format(utils.vtctld.port)
     self.assertEqual(urllib2.urlopen(base + '/explorers/redirect?type=keyspace&explorer=zk&keyspace=test_keyspace').geturl(),
                      base + '/zk/global/vt/keyspaces/test_keyspace')
     self.assertEqual(urllib2.urlopen(base + '/explorers/redirect?type=shard&explorer=zk&keyspace=test_keyspace&shard=-80').geturl(),
                      base + '/zk/global/vt/keyspaces/test_keyspace/shards/-80')
-    self.assertEqual(urllib2.urlopen(base + '/explorers/redirect?type=tablet&explorer=zk&alias=%s' % shard_0_replica.tablet_alias).geturl(),
+    self.assertEqual(urllib2.urlopen(base + '/explorers/redirect?type=tablet&explorer=zk&alias={0!s}'.format(shard_0_replica.tablet_alias)).geturl(),
                      base + shard_0_replica.zk_tablet_path)
 
     self.assertEqual(urllib2.urlopen(base + '/explorers/redirect?type=srv_keyspace&explorer=zk&keyspace=test_keyspace&cell=test_nj').geturl(),
@@ -218,7 +218,7 @@ class TestVtctld(unittest.TestCase):
 
   def test_vtgate(self):
     # do a few vtgate topology queries to prime the cache
-    vtgate_client = zkocc.ZkOccConnection("localhost:%u" % vtgate_port,
+    vtgate_client = zkocc.ZkOccConnection("localhost:{0:d}".format(vtgate_port),
                                           "test_nj", 30.0)
     vtgate_client.dial()
     vtgate_client.get_srv_keyspace_names("test_nj")
@@ -230,7 +230,7 @@ class TestVtctld(unittest.TestCase):
     self.assertIn('</html>', status) # end of page
     self.assertIn('/serving_graph/test_nj">test_nj', status) # vtctld link
 
-    utils.pause("You can now run a browser and connect to http://%s:%u%s to manually check vtgate status page" % (socket.getfqdn(), vtgate_port, environment.status_url))
+    utils.pause("You can now run a browser and connect to http://{0!s}:{1:d}{2!s} to manually check vtgate status page".format(socket.getfqdn(), vtgate_port, environment.status_url))
 
 if __name__ == '__main__':
   utils.main()

--- a/test/vtdb_test.py
+++ b/test/vtdb_test.py
@@ -149,7 +149,7 @@ def setup_tablets():
                            'Partitions(replica): -80 80-\n')
 
   vtgate_server, vtgate_port = utils.vtgate_start()
-  vtgate_client = zkocc.ZkOccConnection("localhost:%u" % vtgate_port,
+  vtgate_client = zkocc.ZkOccConnection("localhost:{0:d}".format(vtgate_port),
                                         "test_nj", 30.0)
   topology.read_topology(vtgate_client)
 
@@ -160,8 +160,8 @@ def get_connection(db_type='master', shard_index=0, user=None, password=None):
   timeout = 10.0
   conn = None
   shard = shard_names[shard_index]
-  vtgate_addrs = {"vt": ["localhost:%s" % (vtgate_port),]}
-  vtgate_client = zkocc.ZkOccConnection("localhost:%u" % vtgate_port,
+  vtgate_addrs = {"vt": ["localhost:{0!s}".format((vtgate_port)),]}
+  vtgate_client = zkocc.ZkOccConnection("localhost:{0:d}".format(vtgate_port),
                                         "test_nj", 30.0)
   conn = vtclient.VtOCCConnection(vtgate_client, 'test_keyspace', shard,
                                   db_type, timeout,
@@ -179,7 +179,7 @@ def do_write(count):
   for x in xrange(count):
     keyspace_id = kid_list[count%len(kid_list)]
     master_conn._execute("insert into vt_insert_test (msg, keyspace_id) values (%(msg)s, %(keyspace_id)s)",
-                         {'msg': 'test %s' % x, 'keyspace_id': keyspace_id})
+                         {'msg': 'test {0!s}'.format(x), 'keyspace_id': keyspace_id})
   master_conn.commit()
 
 
@@ -193,13 +193,12 @@ class TestTabletFunctions(unittest.TestCase):
     try:
       master_conn = get_connection(db_type='master', shard_index=self.shard_index)
     except Exception, e:
-      self.fail("Connection to shard0 master failed with error %s" % str(e))
+      self.fail("Connection to shard0 master failed with error {0!s}".format(str(e)))
     self.assertNotEqual(master_conn, None)
     try:
       replica_conn = get_connection(db_type='replica', shard_index=self.shard_index)
     except Exception, e:
-      logging.debug("Connection to %s replica failed with error %s" %
-                    (shard_names[self.shard_index], str(e)))
+      logging.debug("Connection to {0!s} replica failed with error {1!s}".format(shard_names[self.shard_index], str(e)))
       raise
     self.assertNotEqual(replica_conn, None)
     self.assertIsInstance(master_conn.conn, conn_class,
@@ -217,13 +216,13 @@ class TestTabletFunctions(unittest.TestCase):
       for x in xrange(count):
         keyspace_id = kid_list[count%len(kid_list)]
         master_conn._execute("insert into vt_insert_test (msg, keyspace_id) values (%(msg)s, %(keyspace_id)s)",
-                             {'msg': 'test %s' % x, 'keyspace_id': keyspace_id})
+                             {'msg': 'test {0!s}'.format(x), 'keyspace_id': keyspace_id})
       master_conn.commit()
       results, rowcount = master_conn._execute("select * from vt_insert_test",
                                                {})[:2]
       self.assertEqual(rowcount, count, "master fetch works")
     except Exception, e:
-      logging.debug("Write failed with error %s" % str(e))
+      logging.debug("Write failed with error {0!s}".format(str(e)))
       raise
 
   def test_batch_read(self):
@@ -236,7 +235,7 @@ class TestTabletFunctions(unittest.TestCase):
       for x in xrange(count):
         keyspace_id = kid_list[count%len(kid_list)]
         master_conn._execute("insert into vt_insert_test (msg, keyspace_id) values (%(msg)s, %(keyspace_id)s)",
-                             {'msg': 'test %s' % x, 'keyspace_id': keyspace_id})
+                             {'msg': 'test {0!s}'.format(x), 'keyspace_id': keyspace_id})
       master_conn.commit()
       master_conn.begin()
       master_conn._execute("delete from vt_a", {})
@@ -251,7 +250,7 @@ class TestTabletFunctions(unittest.TestCase):
       self.assertEqual(rowsets[0][1], count)
       self.assertEqual(rowsets[1][1], count)
     except Exception, e:
-      self.fail("Write failed with error %s %s" % (str(e),
+      self.fail("Write failed with error {0!s} {1!s}".format(str(e),
                                                    traceback.print_exc()))
 
   def test_batch_write(self):
@@ -266,7 +265,7 @@ class TestTabletFunctions(unittest.TestCase):
       for x in xrange(count):
         keyspace_id = kid_list[count%len(kid_list)]
         query_list.append("insert into vt_insert_test (msg, keyspace_id) values (%(msg)s, %(keyspace_id)s)")
-        bind_vars_list.append({'msg': 'test %s' % x, 'keyspace_id': keyspace_id})
+        bind_vars_list.append({'msg': 'test {0!s}'.format(x), 'keyspace_id': keyspace_id})
       query_list.append("delete from vt_a")
       bind_vars_list.append({})
       for x in xrange(count):
@@ -281,7 +280,7 @@ class TestTabletFunctions(unittest.TestCase):
       results, rowcount, _, _ = master_conn._execute("select * from vt_a", {})
       self.assertEqual(rowcount, count)
     except Exception, e:
-      self.fail("Write failed with error %s" % str(e))
+      self.fail("Write failed with error {0!s}".format(str(e)))
 
   def test_streaming_fetchsubset(self):
     try:
@@ -299,7 +298,7 @@ class TestTabletFunctions(unittest.TestCase):
       self.assertEqual(rowcount, fetch_size)
       stream_cursor.close()
     except Exception, e:
-      self.fail("Failed with error %s %s" % (str(e), traceback.print_exc()))
+      self.fail("Failed with error {0!s} {1!s}".format(str(e), traceback.print_exc()))
 
   def test_streaming_fetchall(self):
     try:
@@ -316,7 +315,7 @@ class TestTabletFunctions(unittest.TestCase):
       self.assertEqual(rowcount, count)
       stream_cursor.close()
     except Exception, e:
-      self.fail("Failed with error %s %s" % (str(e), traceback.print_exc()))
+      self.fail("Failed with error {0!s} {1!s}".format(str(e), traceback.print_exc()))
 
   def test_streaming_fetchone(self):
     try:
@@ -330,7 +329,7 @@ class TestTabletFunctions(unittest.TestCase):
       self.assertTrue(type(rows) == tuple, "Received a valid row")
       stream_cursor.close()
     except Exception, e:
-      self.fail("Failed with error %s %s" % (str(e), traceback.print_exc()))
+      self.fail("Failed with error {0!s} {1!s}".format(str(e), traceback.print_exc()))
 
   def test_streaming_zero_results(self):
     try:
@@ -347,7 +346,7 @@ class TestTabletFunctions(unittest.TestCase):
         rowcount +=1
       self.assertEqual(rowcount, 0)
     except Exception, e:
-      self.fail("Failed with error %s %s" % (str(e), traceback.print_exc()))
+      self.fail("Failed with error {0!s} {1!s}".format(str(e), traceback.print_exc()))
 
 class TestFailures(unittest.TestCase):
   def setUp(self):
@@ -359,7 +358,7 @@ class TestFailures(unittest.TestCase):
     try:
       replica_conn = get_connection(db_type='replica', shard_index=self.shard_index)
     except Exception, e:
-      self.fail("Connection to shard %s replica failed with error %s" % (shard_names[self.shard_index], str(e)))
+      self.fail("Connection to shard {0!s} replica failed with error {1!s}".format(shard_names[self.shard_index], str(e)))
     self.replica_tablet.kill_vttablet()
     with self.assertRaises(dbexceptions.OperationalError):
       replica_conn._execute("select 1 from vt_insert_test", {})
@@ -367,13 +366,13 @@ class TestFailures(unittest.TestCase):
     try:
       results = replica_conn._execute("select 1 from vt_insert_test", {})
     except Exception, e:
-      self.fail("Communication with shard %s replica failed with error %s" % (shard_names[self.shard_index], str(e)))
+      self.fail("Communication with shard {0!s} replica failed with error {1!s}".format(shard_names[self.shard_index], str(e)))
 
   def test_tablet_restart_stream_execute(self):
     try:
       replica_conn = get_connection(db_type='replica', shard_index=self.shard_index)
     except Exception, e:
-      self.fail("Connection to %s replica failed with error %s" % (shard_names[self.shard_index], str(e)))
+      self.fail("Connection to {0!s} replica failed with error {1!s}".format(shard_names[self.shard_index], str(e)))
     stream_cursor = cursor.StreamCursor(replica_conn)
     self.replica_tablet.kill_vttablet()
     with self.assertRaises(dbexceptions.OperationalError):
@@ -383,14 +382,14 @@ class TestFailures(unittest.TestCase):
     try:
       stream_cursor.execute("select * from vt_insert_test", {})
     except Exception, e:
-      self.fail("Communication with shard0 replica failed with error %s" %
-                str(e))
+      self.fail("Communication with shard0 replica failed with error {0!s}".format(
+                str(e)))
 
   def test_tablet_restart_begin(self):
     try:
       master_conn = get_connection(db_type='master')
     except Exception, e:
-      self.fail("Connection to shard0 master failed with error %s" % str(e))
+      self.fail("Connection to shard0 master failed with error {0!s}".format(str(e)))
     self.master_tablet.kill_vttablet()
     with self.assertRaises(dbexceptions.OperationalError):
       master_conn.begin()
@@ -401,7 +400,7 @@ class TestFailures(unittest.TestCase):
     try:
       master_conn = get_connection(db_type='master')
     except Exception, e:
-      self.fail("Connection to shard0 master failed with error %s" % str(e))
+      self.fail("Connection to shard0 master failed with error {0!s}".format(str(e)))
     with self.assertRaises(dbexceptions.OperationalError):
       master_conn.begin()
       self.master_tablet.kill_vttablet()
@@ -411,7 +410,7 @@ class TestFailures(unittest.TestCase):
     try:
       master_conn = get_connection(db_type='master')
     except Exception, e:
-      self.fail("Connection to shard0 master failed with error %s" % str(e))
+      self.fail("Connection to shard0 master failed with error {0!s}".format(str(e)))
     master_conn.begin()
     master_conn._execute("delete from vt_insert_test", {})
     master_conn.commit()
@@ -420,14 +419,14 @@ class TestFailures(unittest.TestCase):
     try:
       replica_conn = get_connection(db_type='replica', shard_index=self.shard_index)
     except Exception, e:
-      self.fail("Connection to shard0 replica failed with error %s" % str(e))
+      self.fail("Connection to shard0 replica failed with error {0!s}".format(str(e)))
     with self.assertRaises(dbexceptions.TimeoutError):
       replica_conn._execute("select sleep(12) from dual", {})
 
     try:
       master_conn = get_connection(db_type='master')
     except Exception, e:
-      self.fail("Connection to shard0 master failed with error %s" % str(e))
+      self.fail("Connection to shard0 master failed with error {0!s}".format(str(e)))
     with self.assertRaises(dbexceptions.TimeoutError):
       master_conn._execute("select sleep(12) from dual", {})
 
@@ -435,7 +434,7 @@ class TestFailures(unittest.TestCase):
     try:
       replica_conn = get_connection(db_type='replica', shard_index=self.shard_index)
     except Exception, e:
-      self.fail("Connection to shard0 replica failed with error %s" % str(e))
+      self.fail("Connection to shard0 replica failed with error {0!s}".format(str(e)))
     utils.wait_procs([self.replica_tablet.shutdown_mysql(),])
     with self.assertRaises(dbexceptions.DatabaseError):
       replica_conn._execute("select 1 from vt_insert_test", {})
@@ -466,7 +465,7 @@ class TestFailures(unittest.TestCase):
     for x in xrange(count):
       keyspace_id = kid_list[count%len(kid_list)]
       master_conn._execute("insert into vt_insert_test (msg, keyspace_id) values (%(msg)s, %(keyspace_id)s)",
-                           {'msg': 'test %s' % x, 'keyspace_id': keyspace_id})
+                           {'msg': 'test {0!s}'.format(x), 'keyspace_id': keyspace_id})
     master_conn.commit()
 
     self.master_tablet.mquery(self.master_tablet.dbname, "set global read_only=on")
@@ -494,7 +493,7 @@ class TestExceptionLogging(unittest.TestCase):
     try:
       master_conn = get_connection(db_type='master', shard_index=self.shard_index)
     except Exception, e:
-      self.fail("Connection to shard0 master failed with error %s" % str(e))
+      self.fail("Connection to shard0 master failed with error {0!s}".format(str(e)))
 
     master_conn.begin()
     master_conn._execute("delete from vt_a", {})
@@ -519,9 +518,9 @@ class TestExceptionLogging(unittest.TestCase):
       exc_msg = parts[0]
       for kw in DML_KEYWORDS:
         if kw in exc_msg:
-          self.fail("IntegrityError shouldn't contain the query %s" % exc_msg)
+          self.fail("IntegrityError shouldn't contain the query {0!s}".format(exc_msg))
     except Exception as e:
-      self.fail("Expected IntegrityError to be raised, instead raised %s" % str(e))
+      self.fail("Expected IntegrityError to be raised, instead raised {0!s}".format(str(e)))
     finally:
       master_conn.rollback()
     # The underlying execute is expected to catch and log the integrity error.
@@ -577,7 +576,7 @@ class TestAuthentication(unittest.TestCase):
                                   password=self.password)
     replica_conn.connect()
     challenge = ""
-    proof =  "%s %s" %(self.user, hmac.HMAC(self.password,
+    proof =  "{0!s} {1!s}".format(self.user, hmac.HMAC(self.password,
                                             challenge).hexdigest())
     self.assertRaises(gorpc.AppError, replica_conn.conn.client.call,
                       'AuthenticatorCRAMMD5.Authenticate', {"Proof": proof})
@@ -593,7 +592,7 @@ class TestAuthentication(unittest.TestCase):
       except gorpc.GoRpcError:
         break
     else:
-      self.fail("Too many requests were allowed (%s)." % (i + 1))
+      self.fail("Too many requests were allowed ({0!s}).".format((i + 1)))
 
 
 class LocalLogger(vtdb_logger.VtdbLogger):
@@ -624,7 +623,7 @@ class TestTopoReResolve(unittest.TestCase):
     vtdb_logger.register_vtdb_logger(LocalLogger())
     # Lowering the keyspace refresh throttle so things are testable.
     topology.set_keyspace_fetch_throttle(0.1)
-    self.vtgate_client = zkocc.ZkOccConnection("localhost:%u" % vtgate_port,
+    self.vtgate_client = zkocc.ZkOccConnection("localhost:{0:d}".format(vtgate_port),
                                                "test_nj", 30.0)
 
   def test_topo_read_threshold(self):
@@ -632,7 +631,7 @@ class TestTopoReResolve(unittest.TestCase):
     # Check original state.
     keyspace_obj = topology.get_keyspace('test_keyspace')
     self.assertNotEqual(keyspace_obj, None, "test_keyspace should be not None")
-    self.assertEqual(keyspace_obj.sharding_col_type, keyrange_constants.KIT_UINT64, "ShardingColumnType be %s" % keyrange_constants.KIT_UINT64)
+    self.assertEqual(keyspace_obj.sharding_col_type, keyrange_constants.KIT_UINT64, "ShardingColumnType be {0!s}".format(keyrange_constants.KIT_UINT64))
 
     # Change the keyspace object.
     utils.run_vtctl(['SetKeyspaceShardingInfo', '-force', 'test_keyspace',
@@ -646,7 +645,7 @@ class TestTopoReResolve(unittest.TestCase):
     keyspace_obj = topology.get_keyspace('test_keyspace')
     after_1st_clear = vtdb_logger.get_logger().get_topo_rtt()
     self.assertEqual(after_1st_clear - before_topo_rtt, 1, "One additional round-trips to topo server")
-    self.assertEqual(keyspace_obj.sharding_col_type, keyrange_constants.KIT_BYTES, "ShardingColumnType be %s" % keyrange_constants.KIT_BYTES)
+    self.assertEqual(keyspace_obj.sharding_col_type, keyrange_constants.KIT_BYTES, "ShardingColumnType be {0!s}".format(keyrange_constants.KIT_BYTES))
 
     # Refresh without sleeping for throttle time shouldn't cause additional rtt.
     topology.refresh_keyspace(self.vtgate_client, 'test_keyspace')
@@ -659,7 +658,7 @@ class TestTopoReResolve(unittest.TestCase):
     try:
       replica_conn = get_connection(db_type='replica', shard_index=self.shard_index)
     except Exception, e:
-      self.fail("Connection to shard %s replica failed with error %s" % (shard_names[self.shard_index], str(e)))
+      self.fail("Connection to shard {0!s} replica failed with error {1!s}".format(shard_names[self.shard_index], str(e)))
     self.replica_tablet.kill_vttablet()
     time.sleep(self.keyspace_fetch_throttle)
 

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -247,7 +247,7 @@ def tearDownModule():
 def get_connection(user=None, password=None):
   global vtgate_port
   timeout = 10.0
-  return vtgatev3.connect("localhost:%s" % (vtgate_port), timeout,
+  return vtgatev3.connect("localhost:{0!s}".format((vtgate_port)), timeout,
                             user=user, password=password)
 
 
@@ -266,7 +266,7 @@ class TestVTGateFunctions(unittest.TestCase):
       cursor.begin()
       cursor.execute(
           "insert into vt_user (name) values (:name)",
-          {'name': 'test %s' % i})
+          {'name': 'test {0!s}'.format(i)})
       self.assertEqual((cursor.fetchall(), cursor.rowcount, cursor.lastrowid, cursor.description), ([], 1L, i, []))
       cursor.commit()
 
@@ -274,7 +274,7 @@ class TestVTGateFunctions(unittest.TestCase):
     for x in xrange(count):
       i = x+1
       cursor.execute("select * from vt_user where id = :id", {'id': i})
-      self.assertEqual((cursor.fetchall(), cursor.rowcount, cursor.lastrowid, cursor.description), ([(i, "test %s" % i)], 1L, 0, [('id', 8L), ('name', 253L)]))
+      self.assertEqual((cursor.fetchall(), cursor.rowcount, cursor.lastrowid, cursor.description), ([(i, "test {0!s}".format(i))], 1L, 0, [('id', 8L), ('name', 253L)]))
 
     # Test insert with no auto-inc, then auto-inc
     vtgate_conn.begin()
@@ -443,14 +443,14 @@ class TestVTGateFunctions(unittest.TestCase):
       vtgate_conn.begin()
       result = vtgate_conn._execute(
           "insert into vt_user_extra (user_id, email) values (:user_id, :email)",
-          {'user_id': i, 'email': 'test %s' % i},
+          {'user_id': i, 'email': 'test {0!s}'.format(i)},
           'master')
       self.assertEqual(result, ([], 1L, 0L, []))
       vtgate_conn.commit()
     for x in xrange(count):
       i = x+1
       result = vtgate_conn._execute("select * from vt_user_extra where user_id = :user_id", {'user_id': i}, 'master')
-      self.assertEqual(result, ([(i, "test %s" % i)], 1L, 0, [('user_id', 8L), ('email', 253L)]))
+      self.assertEqual(result, ([(i, "test {0!s}".format(i))], 1L, 0, [('user_id', 8L), ('email', 253L)]))
     result = shard_0_master.mquery("vt_user", "select * from vt_user_extra")
     self.assertEqual(result, ((1L, 'test 1'), (2L, 'test 2'), (3L, 'test 3')))
     result = shard_1_master.mquery("vt_user", "select * from vt_user_extra")
@@ -499,14 +499,14 @@ class TestVTGateFunctions(unittest.TestCase):
       vtgate_conn.begin()
       result = vtgate_conn._execute(
           "insert into vt_music (user_id, song) values (:user_id, :song)",
-          {'user_id': i, 'song': 'test %s' % i},
+          {'user_id': i, 'song': 'test {0!s}'.format(i)},
           'master')
       self.assertEqual(result, ([], 1L, i, []))
       vtgate_conn.commit()
     for x in xrange(count):
       i = x+1
       result = vtgate_conn._execute("select * from vt_music where id = :id", {'id': i}, 'master')
-      self.assertEqual(result, ([(i, i, "test %s" % i)], 1, 0, [('user_id', 8L), ('id', 8L), ('song', 253L)]))
+      self.assertEqual(result, ([(i, i, "test {0!s}".format(i))], 1, 0, [('user_id', 8L), ('id', 8L), ('song', 253L)]))
     vtgate_conn.begin()
     result = vtgate_conn._execute(
         "insert into vt_music (user_id, id, song) values (:user_id, :id, :song)",

--- a/test/worker.py
+++ b/test/worker.py
@@ -172,7 +172,7 @@ class TestBaseSplitCloneResiliency(unittest.TestCase):
       tablet.wait_for_vttablet_state(wait_state)
 
     # Reparent to choose an initial master
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/%s' % shard_name,
+    utils.run_vtctl(['InitShardMaster', 'test_keyspace/{0!s}'.format(shard_name),
                      shard_tablets.master.tablet_alias], auto_log=True)
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
 
@@ -201,15 +201,15 @@ class TestBaseSplitCloneResiliency(unittest.TestCase):
       msg - the value of `msg` column
       keyspace_id - the value of `keyspace_id` column
     """
-    k = "%u" % keyspace_id
+    k = "{0:d}".format(keyspace_id)
     values_str = ''
     for i in xrange(num_values):
       if i != 0:
         values_str += ','
-      values_str += '(%u, "%s", 0x%x)' % (id_offset + i, msg, keyspace_id)
+      values_str += '({0:d}, "{1!s}", 0x{2:x})'.format(id_offset + i, msg, keyspace_id)
     tablet.mquery('vt_test_keyspace', [
         'begin',
-        'insert into worker_test(id, msg, keyspace_id) values%s /* EMD keyspace_id:%s*/' % (values_str, k),
+        'insert into worker_test(id, msg, keyspace_id) values{0!s} /* EMD keyspace_id:{1!s}*/'.format(values_str, k),
         'commit'
         ], write=True)
 
@@ -232,7 +232,7 @@ class TestBaseSplitCloneResiliency(unittest.TestCase):
     for shard_num in xrange(num_shards):
         self._insert_values(tablet,
                             shard_offsets[shard_num] + offset,
-                            'msg-shard-%u' % shard_num,
+                            'msg-shard-{0:d}'.format(shard_num),
                             shard_offsets[shard_num],
                             num_values)
 
@@ -244,7 +244,7 @@ class TestBaseSplitCloneResiliency(unittest.TestCase):
       source_tablet - Tablet instance of the source shard
       destination_tablet - Tablet instance of the destination shard
     """
-    select_query = 'select * from worker_test where msg="msg-shard-%s" order by id asc' % shard_num
+    select_query = 'select * from worker_test where msg="msg-shard-{0!s}" order by id asc'.format(shard_num)
 
     # Make sure all the right rows made it from the source to the destination
     source_rows = source_tablet.mquery('vt_test_keyspace', select_query)
@@ -265,7 +265,7 @@ class TestBaseSplitCloneResiliency(unittest.TestCase):
       source_tablets - ShardTablets instance for the source shard
       destination_tablets - ShardTablets instance for the destination shard
     """
-    logging.debug("Running vtworker SplitDiff for %s" % keyspace_shard)
+    logging.debug("Running vtworker SplitDiff for {0!s}".format(keyspace_shard))
     stdout, stderr = utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff',
       keyspace_shard], auto_log=True)
 
@@ -311,7 +311,7 @@ class TestBaseSplitCloneResiliency(unittest.TestCase):
         tablet.kill_vttablet()
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
     for shard in ['0', '-80', '80-']:
-      utils.run_vtctl(['DeleteShard', 'test_keyspace/%s' % shard], auto_log=True)
+      utils.run_vtctl(['DeleteShard', 'test_keyspace/{0!s}'.format(shard)], auto_log=True)
 
   def verify_successful_worker_copy_with_reparent(self, mysql_down=False):
     """Verifies that vtworker can succesfully copy data for a SplitClone.

--- a/test/zkocc_test.py
+++ b/test/zkocc_test.py
@@ -62,7 +62,7 @@ class TopoOccTest(unittest.TestCase):
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace*'], auto_log=True)
 
     # vtgate API test
-    out, err = utils.run(environment.binary_argstr('zkclient2')+' -server localhost:%u -mode getSrvKeyspaceNames test_nj' % self.vtgate_zk_port, trap_output=True)
+    out, err = utils.run(environment.binary_argstr('zkclient2')+' -server localhost:{0:d} -mode getSrvKeyspaceNames test_nj'.format(self.vtgate_zk_port), trap_output=True)
     self.assertEqual(err, "KeyspaceNames[0] = test_keyspace1\n" +
                           "KeyspaceNames[1] = test_keyspace2\n")
 
@@ -70,18 +70,18 @@ class TopoOccTest(unittest.TestCase):
     utils.run_vtctl('CreateKeyspace test_keyspace')
     t = tablet.Tablet(tablet_uid=1, cell="nj")
     t.init_tablet("master", "test_keyspace", "0")
-    utils.run_vtctl('UpdateTabletAddrs -hostname localhost -ip-addr 127.0.0.1 -mysql-port %s -vts-port %s %s' % (t.mysql_port, t.port + 500, t.tablet_alias))
+    utils.run_vtctl('UpdateTabletAddrs -hostname localhost -ip-addr 127.0.0.1 -mysql-port {0!s} -vts-port {1!s} {2!s}'.format(t.mysql_port, t.port + 500, t.tablet_alias))
     self.rebuild()
 
     # vtgate zk API test
-    out, err = utils.run(environment.binary_argstr('zkclient2')+' -server localhost:%u -mode getSrvKeyspace test_nj test_keyspace' % self.vtgate_zk_port, trap_output=True)
+    out, err = utils.run(environment.binary_argstr('zkclient2')+' -server localhost:{0:d} -mode getSrvKeyspace test_nj test_keyspace'.format(self.vtgate_zk_port), trap_output=True)
     self.assertEqual(err, "Partitions[master] =\n" +
                      "  ShardReferences[0]={Start: , End: }\n" +
                      "Partitions[rdonly] =\n" +
                      "  ShardReferences[0]={Start: , End: }\n" +
                      "Partitions[replica] =\n" +
                      "  ShardReferences[0]={Start: , End: }\n",
-                     "Got wrong content: %s" % err)
+                     "Got wrong content: {0!s}".format(err))
 
   def test_get_end_points(self):
     utils.run_vtctl('CreateKeyspace test_keyspace')
@@ -91,7 +91,7 @@ class TopoOccTest(unittest.TestCase):
     self.rebuild()
 
     # vtgate zk API test
-    out, err = utils.run(environment.binary_argstr('zkclient2')+' -server localhost:%u -mode getEndPoints test_nj test_keyspace 0 master' % self.vtgate_zk_port, trap_output=True)
+    out, err = utils.run(environment.binary_argstr('zkclient2')+' -server localhost:{0:d} -mode getEndPoints test_nj test_keyspace 0 master'.format(self.vtgate_zk_port), trap_output=True)
     self.assertEqual(err, "Entries[0] = 1 localhost\n")
 
 
@@ -120,7 +120,7 @@ class TestTopo(unittest.TestCase):
         extra_args=['-cpu_profile', os.path.join(environment.tmproot,
                                                  'vtgate.pprof')])
     qpser = utils.run_bg(environment.binary_args('zkclient2') + [
-        '-server', 'localhost:%u' % vtgate_port,
+        '-server', 'localhost:{0:d}'.format(vtgate_port),
         '-mode', 'qps',
         '-zkclient_cpu_profile', os.path.join(environment.tmproot, 'zkclient2.pprof'),
         'test_nj', 'test_keyspace'])
@@ -132,7 +132,7 @@ class TestTopo(unittest.TestCase):
     # some checks on performance / stats
     rpcCalls = v['TopoReaderRpcQueryCount']['test_nj']
     if rpcCalls < MIN_QPS * 10:
-      self.fail('QPS is too low: %u < %u' % (rpcCalls / 10, MIN_QPS))
+      self.fail('QPS is too low: {0:d} < {1:d}'.format(rpcCalls / 10, MIN_QPS))
     else:
       logging.debug("Recorded qps: %u", rpcCalls / 10)
     utils.vtgate_kill(vtgate_proc)

--- a/third_party/py/bson-0.3.2/bson/codec.py
+++ b/third_party/py/bson-0.3.2/bson/codec.py
@@ -27,7 +27,7 @@ unpack_binary_struct = binary_struct.unpack_from
 class MissingClassDefinition(ValueError):
 	def __init__(self, class_name):
 		super(MissingClassDefinition, self).__init__(
-		"No class definition for class %s" % (class_name,))
+		"No class definition for class {0!s}".format(class_name))
 # 
 #  Warning Classes
 class MissingTimezoneWarning(RuntimeWarning):
@@ -108,7 +108,7 @@ def decode_object(raw_values):
 def encode_string(value):
 	value = value.encode("utf8")
 	length = len(value)
-	return struct.pack("<i%dsb" % (length,), length + 1, value, 0)
+	return struct.pack("<i{0:d}sb".format(length), length + 1, value, 0)
 
 def decode_string(data, base):
 	length = unpack_length(data, base)[0]
@@ -204,7 +204,7 @@ def encode_document(obj, traversal_stack,
 		traversal_stack.pop()
 	e_list = buf.getvalue()
 	e_list_length = len(e_list)
-	return struct.pack("<i%dsb" % (e_list_length,), e_list_length + 4 + 1,
+	return struct.pack("<i{0:d}sb".format(e_list_length), e_list_length + 4 + 1,
 			e_list, 0)
 
 def encode_array(array, traversal_stack,
@@ -217,7 +217,7 @@ def encode_array(array, traversal_stack,
 		traversal_stack.pop()
 	e_list = buf.getvalue()
 	e_list_length = len(e_list)
-	return struct.pack("<i%dsb" % (e_list_length,), e_list_length + 4 + 1,
+	return struct.pack("<i{0:d}sb".format(e_list_length), e_list_length + 4 + 1,
 			e_list, 0)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:vitess?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:vitess?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
